### PR TITLE
Consolidate dirs deps

### DIFF
--- a/russh-config/Cargo.toml
+++ b/russh-config/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.7.1"
 rust-version = "1.65"
 
 [dependencies]
-dirs-next = "2.0"
+home = "0.5"
 futures = { workspace = true }
 globset = "0.4.14"
 log = { workspace = true }

--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -86,7 +86,7 @@ impl Config {
 }
 
 pub fn parse_home(host: &str) -> Result<Config, Error> {
-    let mut home = if let Some(home) = dirs_next::home_dir() {
+    let mut home = if let Some(home) = home::home_dir() {
         home
     } else {
         return Err(Error::NoHome);
@@ -135,7 +135,7 @@ pub fn parse(file: &str, host: &str) -> Result<Config, Error> {
                     "identityfile" => {
                         let id = value.trim_start();
                         if id.starts_with("~/") {
-                            if let Some(mut home) = dirs_next::home_dir() {
+                            if let Some(mut home) = home::home_dir() {
                                 home.push(id.split_at(2).1);
                                 config.identity_file = Some(
                                     home.to_str()

--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -22,7 +22,7 @@ byteorder = { workspace = true }
 data-encoding = "2.3"
 digest = { workspace = true }
 der = "0.7"
-dirs = "5.0"
+home = "0.5"
 ecdsa = "0.16"
 ed25519-dalek = { version = "2.0", features = ["rand_core", "pkcs8"] }
 elliptic-curve = "0.13"

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -503,7 +503,7 @@ pub fn check_known_hosts_path<P: AsRef<Path>>(
 
 #[cfg(target_os = "windows")]
 fn known_hosts_path() -> Result<PathBuf, Error> {
-    if let Some(home_dir) = dirs::home_dir() {
+    if let Some(home_dir) = home::home_dir() {
         Ok(home_dir.join("ssh").join("known_hosts"))
     } else {
         Err(Error::NoHomeDir)
@@ -512,7 +512,7 @@ fn known_hosts_path() -> Result<PathBuf, Error> {
 
 #[cfg(not(target_os = "windows"))]
 fn known_hosts_path() -> Result<PathBuf, Error> {
-    if let Some(home_dir) = dirs::home_dir() {
+    if let Some(home_dir) = home::home_dir() {
         Ok(home_dir.join(".ssh").join("known_hosts"))
     } else {
         Err(Error::NoHomeDir)


### PR DESCRIPTION
It seems like the project ended up with two different dependencies providing access to the home directory.
This PR consolidates these dependencies into a single dependency.

I've done so by using the `home` crate since on linux it has 0 dependencies and is well supported due to being a part of the cargo repo.
But if you'd prefer I could swap this PR to use `dirs-next`.

I would like to avoid `dirs` since it is pulling in strange dependencies https://github.com/dirs-dev/dirs-sys-rs/pull/26