### PR TITLE
Update Cargo.toml

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -27,7 +27,7 @@ bitflags = "2.0"
 byteorder = { workspace = true }
 chacha20 = "0.9"
 ctr = "0.9"
-curve25519-dalek = "4.1.2"
+curve25519-dalek = "4.1.3"
 digest = { workspace = true }
 elliptic-curve = { version = "0.13", features = ["ecdh"] }
 flate2 = { version = "1.0", optional = true }


### PR DESCRIPTION
Bumps the dependency to at least 4.1.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0344.html) 

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)