### PR TITLE
Remove leftover extraneous debugging in host globbing function

### DIFF
--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -185,7 +185,6 @@ pub fn parse(file: &str, host: &str) -> Result<Config, Error> {
 }
 
 fn check_host_against_glob_pattern(candidate: &str, glob_pattern: &str) -> bool {
-    dbg!(candidate, glob_pattern);
     match Glob::new(glob_pattern) {
         Ok(glob) => glob.compile_matcher().is_match(candidate),
         _ => false,


### PR DESCRIPTION
Apologies. I accidentally left a stray dbg!() in when checking the glob expansion logic of hosts in the russh-config SSH config parsing code. This PR simply removes it.