### PR TITLE
Improve echoserver example, bump Rust toolchain to 1.81

### DIFF
--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -960,7 +960,7 @@ ocyR
     fn test_decode_encode_symmetry(key: &str) {
         let original_key_bytes = data_encoding::BASE64_MIME
             .decode(
-                &key.lines()
+                key.lines()
                     .filter(|line| !line.starts_with("-----"))
                     .collect::<Vec<&str>>()
                     .join("")
@@ -1013,7 +1013,7 @@ ocyR
             sig.extend_ssh_string(&[0]);
             sig.extend_ssh_string(&[0]);
             let public = key.clone_public_key().unwrap();
-            assert_eq!(false, public.verify_detached(buf, &sig));
+            assert!(!public.verify_detached(buf, &sig));
         }
     }
 
@@ -1369,12 +1369,9 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
             let (_, buf) = client.sign_request(&public, buf).await;
             let buf = buf?;
             let (a, b) = buf.split_at(len);
-            match key {
-                key::KeyPair::Ed25519 { .. } => {
-                    let sig = &b[b.len() - 64..];
-                    assert!(public.verify_detached(a, sig));
-                }
-                _ => {}
+            if let key::KeyPair::Ed25519 { .. } = key {
+                let sig = &b[b.len() - 64..];
+                assert!(public.verify_detached(a, sig));
             }
             Ok::<(), Error>(())
         })

--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -91,7 +91,7 @@ impl server::Handler for Server {
         if data == [3] {
             return Err(russh::Error::Disconnect);
         }
-        
+
         let data = CryptoVec::from(format!("Got data: {}\r\n", String::from_utf8_lossy(data)));
         self.post(data.clone()).await;
         session.data(channel, data);

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -137,7 +137,9 @@ pub struct AuthRequest {
 #[derive(Debug)]
 pub enum CurrentRequest {
     PublicKey {
+        #[allow(dead_code)]
         key: CryptoVec,
+        #[allow(dead_code)]
         algo: CryptoVec,
         sent_pk_ok: bool,
     },

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -208,10 +208,10 @@ pub(crate) trait SealingKey {
 
         // Maximum packet length:
         // https://tools.ietf.org/html/rfc4253#section-6.1
-        assert!(packet_length <= std::u32::MAX as usize);
+        assert!(packet_length <= u32::MAX as usize);
         buffer.buffer.push_u32_be(packet_length as u32);
 
-        assert!(padding_length <= std::u8::MAX as usize);
+        assert!(padding_length <= u8::MAX as usize);
         buffer.buffer.push(padding_length as u8);
         buffer.buffer.extend(payload);
         self.fill_padding(buffer.buffer.resize_mut(padding_length));

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -300,7 +300,7 @@ impl<H: Handler> Handle<H> {
     /// complete Keyboard-Interactive based SSH authentication.
     ///
     /// * `responses` - The responses to each prompt. The number of responses must match the number
-    /// of prompts. If a prompt has an empty string, then the response should be an empty string.
+    ///   of prompts. If a prompt has an empty string, then the response should be an empty string.
     pub async fn authenticate_keyboard_interactive_respond(
         &mut self,
         responses: Vec<String>,

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -30,7 +30,7 @@ impl SshId {
     pub(crate) fn as_kex_hash_bytes(&self) -> &[u8] {
         match self {
             Self::Standard(s) => s.as_bytes(),
-            Self::Raw(s) => s.trim_end_matches(|c| c == '\n' || c == '\r').as_bytes(),
+            Self::Raw(s) => s.trim_end_matches(['\n', '\r']).as_bytes(),
         }
     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.76.0"
+channel = "1.81.0"


### PR DESCRIPTION
While trying out the echoserver, I've added some error handling and made the session closable with ctrl+c, which might often be what you want. So I thought upstreaming these changes might be a good thing.

While on it, I took the liberty of bumping the rust toolchain to 1.81, which does not seem to break anything.