### PR TITLE
feat(wasm): Add util creates for runtime,future and time primitives for wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["russh-keys", "russh", "russh-config", "cryptovec", "pageant"]
+members = ["russh-keys", "russh", "russh-config", "cryptovec", "pageant", "russh-util"]
 
 [patch.crates-io]
 russh = { path = "russh" }

--- a/russh-util/Cargo.toml
+++ b/russh-util/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "russh-util"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chrono = "0.4.38"
+
+[dev-dependencies]
+futures-executor = "0.3.13"
+static_assertions = "1.1.0"
+
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.43"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tokio = { version = "1.17", features = [
+    "io-util",
+    "macros",
+    "sync",
+    "rt-multi-thread",
+    "rt",
+] }

--- a/russh-util/src/future.rs
+++ b/russh-util/src/future.rs
@@ -1,0 +1,157 @@
+use std::alloc::Layout;
+use std::fmt;
+use std::future::{self, Future};
+use std::mem::{self, ManuallyDrop};
+use std::pin::Pin;
+use std::ptr;
+use std::task::{Context, Poll};
+
+/// A reusable `Pin<Box<dyn Future<Output = T> + Send + 'a>>`.
+///
+/// This type lets you replace the future stored in the box without
+/// reallocating when the size and alignment permits this.
+pub struct ReusableBoxFuture<'a, T> {
+    boxed: Pin<Box<dyn Future<Output = T> + Send + 'a>>,
+}
+
+impl<'a, T> ReusableBoxFuture<'a, T> {
+    /// Create a new `ReusableBoxFuture<T>` containing the provided future.
+    pub fn new<F>(future: F) -> Self
+    where
+        F: Future<Output = T> + Send + 'a,
+    {
+        Self {
+            boxed: Box::pin(future),
+        }
+    }
+
+    /// Replace the future currently stored in this box.
+    ///
+    /// This reallocates if and only if the layout of the provided future is
+    /// different from the layout of the currently stored future.
+    pub fn set<F>(&mut self, future: F)
+    where
+        F: Future<Output = T> + Send + 'a,
+    {
+        if let Err(future) = self.try_set(future) {
+            *self = Self::new(future);
+        }
+    }
+
+    /// Replace the future currently stored in this box.
+    ///
+    /// This function never reallocates, but returns an error if the provided
+    /// future has a different size or alignment from the currently stored
+    /// future.
+    pub fn try_set<F>(&mut self, future: F) -> Result<(), F>
+    where
+        F: Future<Output = T> + Send + 'a,
+    {
+        // If we try to inline the contents of this function, the type checker complains because
+        // the bound `T: 'a` is not satisfied in the call to `pending()`. But by putting it in an
+        // inner function that doesn't have `T` as a generic parameter, we implicitly get the bound
+        // `F::Output: 'a` transitively through `F: 'a`, allowing us to call `pending()`.
+        #[inline(always)]
+        fn real_try_set<'a, F>(
+            this: &mut ReusableBoxFuture<'a, F::Output>,
+            future: F,
+        ) -> Result<(), F>
+        where
+            F: Future + Send + 'a,
+        {
+            // future::Pending<T> is a ZST so this never allocates.
+            let boxed = mem::replace(&mut this.boxed, Box::pin(future::pending()));
+            reuse_pin_box(boxed, future, |boxed| this.boxed = Pin::from(boxed))
+        }
+
+        real_try_set(self, future)
+    }
+
+    /// Get a pinned reference to the underlying future.
+    pub fn get_pin(&mut self) -> Pin<&mut (dyn Future<Output = T> + Send)> {
+        self.boxed.as_mut()
+    }
+
+    /// Poll the future stored inside this box.
+    pub fn poll(&mut self, cx: &mut Context<'_>) -> Poll<T> {
+        self.get_pin().poll(cx)
+    }
+}
+
+impl<T> Future for ReusableBoxFuture<'_, T> {
+    type Output = T;
+
+    /// Poll the future stored inside this box.
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<T> {
+        Pin::into_inner(self).get_pin().poll(cx)
+    }
+}
+
+// The only method called on self.boxed is poll, which takes &mut self, so this
+// struct being Sync does not permit any invalid access to the Future, even if
+// the future is not Sync.
+unsafe impl<T> Sync for ReusableBoxFuture<'_, T> {}
+
+impl<T> fmt::Debug for ReusableBoxFuture<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ReusableBoxFuture").finish()
+    }
+}
+
+fn reuse_pin_box<T: ?Sized, U, O, F>(boxed: Pin<Box<T>>, new_value: U, callback: F) -> Result<O, U>
+where
+    F: FnOnce(Box<U>) -> O,
+{
+    let layout = Layout::for_value::<T>(&*boxed);
+    if layout != Layout::new::<U>() {
+        return Err(new_value);
+    }
+
+    // SAFETY: We don't ever construct a non-pinned reference to the old `T` from now on, and we
+    // always drop the `T`.
+    let raw: *mut T = Box::into_raw(unsafe { Pin::into_inner_unchecked(boxed) });
+
+    // When dropping the old value panics, we still want to call `callback` — so move the rest of
+    // the code into a guard type.
+    let guard = CallOnDrop::new(|| {
+        let raw: *mut U = raw.cast::<U>();
+        unsafe { raw.write(new_value) };
+
+        // SAFETY:
+        // - `T` and `U` have the same layout.
+        // - `raw` comes from a `Box` that uses the same allocator as this one.
+        // - `raw` points to a valid instance of `U` (we just wrote it in).
+        let boxed = unsafe { Box::from_raw(raw) };
+
+        callback(boxed)
+    });
+
+    // Drop the old value.
+    unsafe { ptr::drop_in_place(raw) };
+
+    // Run the rest of the code.
+    Ok(guard.call())
+}
+
+struct CallOnDrop<O, F: FnOnce() -> O> {
+    f: ManuallyDrop<F>,
+}
+
+impl<O, F: FnOnce() -> O> CallOnDrop<O, F> {
+    fn new(f: F) -> Self {
+        let f = ManuallyDrop::new(f);
+        Self { f }
+    }
+    fn call(self) -> O {
+        let mut this = ManuallyDrop::new(self);
+        let f = unsafe { ManuallyDrop::take(&mut this.f) };
+        f()
+    }
+}
+
+impl<O, F: FnOnce() -> O> Drop for CallOnDrop<O, F> {
+    fn drop(&mut self) {
+        let f = unsafe { ManuallyDrop::take(&mut self.f) };
+        f();
+    }
+}

--- a/russh-util/src/future.rs
+++ b/russh-util/src/future.rs
@@ -1,3 +1,5 @@
+/// This file is a copy of the `ReusableBoxFuture` type from the `tokio-util` crate.
+
 use std::alloc::Layout;
 use std::fmt;
 use std::future::{self, Future};

--- a/russh-util/src/lib.rs
+++ b/russh-util/src/lib.rs
@@ -1,0 +1,5 @@
+#![deny(dead_code)] // To be removed when full wasm support is added.
+
+pub mod future;
+pub mod runtime;
+pub mod time;

--- a/russh-util/src/runtime.rs
+++ b/russh-util/src/runtime.rs
@@ -1,0 +1,16 @@
+use std::future::Future;
+
+pub fn spawn<F>(future: F)
+where
+    F: Future<Output = ()> + 'static + Send,
+{
+    #[cfg(target_arch = "wasm32")]
+    {
+        wasm_bindgen_futures::spawn_local(future);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        tokio::spawn(future);
+    }
+}

--- a/russh-util/src/time.rs
+++ b/russh-util/src/time.rs
@@ -1,0 +1,49 @@
+
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std_time::Instant;
+
+
+#[cfg(target_arch = "wasm32")]
+pub use wasm::Instant;
+
+
+
+mod wasm {
+    #[derive(Debug, Clone, Copy)]
+    pub struct Instant {
+        inner: chrono::DateTime<chrono::Utc>,
+    }
+
+    impl Instant {
+        pub fn now() -> Self {
+            Instant {
+                inner: chrono::Utc::now(),
+            }
+        }
+
+        pub fn duration_since(&self, earlier: Instant) -> std::time::Duration {
+            (self.inner - earlier.inner).to_std().expect("Duration is negative")
+        }
+    }
+}
+
+mod std_time {
+    
+    #[derive(Debug, Clone, Copy)]
+    pub struct Instant {
+        inner: std::time::Instant,
+    }
+
+    impl Instant {
+        pub fn now() -> Self {
+            Instant {
+                inner: std::time::Instant::now(),
+            }
+        }
+
+        pub fn duration_since(&self, earlier: Instant) -> std::time::Duration {
+            self.inner.duration_since(earlier.inner)
+        }
+    }
+}


### PR DESCRIPTION
This is the second pull request for supporting WASM.

Introducing russh-util crates to encapsulate platform difference.

Prepare for replacing tokio-util, tokio runtime and std::time::Instant::now.