### PR TITLE
Reject unsupported key types instead of failing

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -519,7 +519,9 @@ impl Encrypted {
                     Ok(())
                 }
             }
-            Err(russh_keys::Error::CouldNotReadKey) | Err(russh_keys::Error::KeyIsCorrupt) => {
+            Err(russh_keys::Error::CouldNotReadKey)
+            | Err(russh_keys::Error::KeyIsCorrupt)
+            | Err(russh_keys::Error::UnsupportedKeyType { .. }) => {
                 reject_auth_request(until, &mut self.write, auth_request).await;
                 Ok(())
             }


### PR DESCRIPTION
Currently russh doesn't support ED25519/ECDSA-SK keys, but OpenSSH will attempt to use them anyway. Key parse will then fail, killing the session.

This should be treated as-if auth_publickey_offered rejects the key.