### PR TITLE
Add ed25519 to ALL_KEY_TYPES

### DIFF
--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -54,6 +54,7 @@ pub const SSH_RSA: Name = Name("ssh-rsa");
 
 pub static ALL_KEY_TYPES: &[&Name] = &[
     &NONE,
+    &ED25519,
     &SSH_RSA,
     &RSA_SHA2_256,
     &RSA_SHA2_512,


### PR DESCRIPTION
Hi - thanks for the crate!

I was trying to make my ssh client only accept `ed25519` keys. To do so, I wanted to do something like 
```rust
Preferred { 
    key: Cow::from([&key::Name::try_from("ssh-ed25519")]),
    ...
}
```
However, the `try_from` will result in `Err(())`, because `ED25519` is not contained in the `ALL_KEY_TYPES` array which is used for the lookup of all possible names.

This PR naively adds `ED25519` to `ALL_KEY_TYPES` it in there. However, there might be a good reason why this wasn't there to begin with, in which case this can of course be closed.