### PR TITLE
refactor: make `clone_public_key` infallible

### DIFF
--- a/russh-keys/src/backend_rust.rs
+++ b/russh-keys/src/backend_rust.rs
@@ -155,13 +155,11 @@ impl<'a> From<&RsaPrivate> for protocol::RsaPublicKey<'a> {
     }
 }
 
-impl TryFrom<&RsaPrivate> for RsaPublic {
-    type Error = Error;
-
-    fn try_from(key: &RsaPrivate) -> Result<Self, Self::Error> {
-        Ok(Self {
+impl From<&RsaPrivate> for RsaPublic {
+    fn from(key: &RsaPrivate) -> Self {
+        Self {
             key: key.key.to_public_key(),
-        })
+        }
     }
 }
 

--- a/russh-keys/src/key.rs
+++ b/russh-keys/src/key.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 use std::borrow::Cow;
-use std::convert::{TryFrom, TryInto};
+use std::convert::TryFrom;
 
 pub use backend::{RsaPrivate, RsaPublic};
 use ed25519_dalek::{Signer, Verifier};
@@ -291,17 +291,17 @@ impl KeyPair {
     }
 
     /// Copy the public key of this algorithm.
-    pub fn clone_public_key(&self) -> Result<PublicKey, Error> {
-        Ok(match self {
+    pub fn clone_public_key(&self) -> PublicKey {
+        match self {
             KeyPair::Ed25519(ref key) => PublicKey::Ed25519(key.verifying_key()),
             KeyPair::RSA { ref key, ref hash } => PublicKey::RSA {
-                key: key.try_into()?,
+                key: key.into(),
                 hash: *hash,
             },
             KeyPair::EC { ref key } => PublicKey::EC {
                 key: key.to_public_key(),
             },
-        })
+        }
     }
 
     /// Name of this key algorithm.

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -45,7 +45,7 @@
 //!        russh_keys::agent::server::serve(tokio_stream::wrappers::UnixListenerStream::new(listener), X {}).await
 //!    });
 //!    let key = decode_secret_key(PKCS8_ENCRYPTED, Some("blabla")).unwrap();
-//!    let public = key.clone_public_key().unwrap();
+//!    let public = key.clone_public_key();
 //!    core.block_on(async move {
 //!        let stream = tokio::net::UnixStream::connect(&agent_path).await?;
 //!        let mut client = agent::client::AgentClient::connect(stream);
@@ -758,7 +758,7 @@ ocyR
         }
         // Verify using public key derived from the secret key.
         {
-            let public = key.clone_public_key().unwrap();
+            let public = key.clone_public_key();
             assert!(public.verify_detached(buf, sig.as_ref()));
         }
         // Sanity check that it uses a different random number.
@@ -787,7 +787,7 @@ ocyR
             let mut sig = Vec::new();
             sig.extend_ssh_string(&[0]);
             sig.extend_ssh_string(&[0]);
-            let public = key.clone_public_key().unwrap();
+            let public = key.clone_public_key();
             assert!(!public.verify_detached(buf, &sig));
         }
     }
@@ -911,7 +911,7 @@ KJaj7gc0n6gmKY6r0/Ddufy1JZ6eihBCSJ64RARBXeg2rZpyT+xxhMEZLK5meOeR
 -----END RSA PRIVATE KEY-----
 ";
         let key = decode_secret_key(key, Some("passphrase")).unwrap();
-        let public = key.clone_public_key()?;
+        let public = key.clone_public_key();
         let buf = b"blabla";
         let sig = key.sign_detached(buf).unwrap();
         assert!(public.verify_detached(buf, sig.as_ref()));
@@ -1052,7 +1052,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
             tokio::time::sleep(std::time::Duration::from_millis(10)).await;
         }
 
-        let public = key.clone_public_key()?;
+        let public = key.clone_public_key();
         let stream = tokio::net::UnixStream::connect(&agent_path).await?;
         let mut client = agent::client::AgentClient::connect(stream);
         client.add_identity(&key, &[]).await?;
@@ -1132,7 +1132,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         });
         let key = decode_secret_key(PKCS8_ENCRYPTED, Some("blabla")).unwrap();
         core.block_on(async move {
-            let public = key.clone_public_key()?;
+            let public = key.clone_public_key();
             let stream = tokio::net::UnixStream::connect(&agent_path).await?;
             let mut client = agent::client::AgentClient::connect(stream);
             client


### PR DESCRIPTION
Hi, I was wondering why `KeyPair::clone_public_key` was fallible.
Turns out only the `RsaPrivate` -> `RsaPublic` conversion used `TryFrom` internally - a `TryFrom` implementation that never failed and just returned `Ok`, so it could just be `From`.
I've switched out `TryFrom` for `From` and switched the Result type for `clone_public_key` from `Result<T>` to `T`.

I've updated the tests and doctests touching `clone_public_key` to use the new signature so they all compile and pass again. 

The only argument I see right now not to change the signature would be for forward compatibility for key types where there actually is a sensible error scenario for extracting the public key, which I find hard to imagine. Please let me know if I'm being ignorant here :thinking: 

Best Regards