### PR TITLE
Support for OpenSSH certificate authentication

### DIFF
--- a/russh-keys/src/agent/client.rs
+++ b/russh-keys/src/agent/client.rs
@@ -550,6 +550,9 @@ fn key_blob(public: &key::PublicKey, buf: &mut CryptoVec) -> Result<(), Error> {
         PublicKey::EC { .. } => {
             buf.extend_ssh_string(&public.public_key_bytes());
         }
+        PublicKey::Certificate(ref cert_data) => {
+            key_blob(&cert_data.pubkey, buf)?;
+        }
     }
     Ok(())
 }

--- a/russh-keys/src/encoding.rs
+++ b/russh-keys/src/encoding.rs
@@ -261,6 +261,12 @@ impl<'a> Position<'a> {
             Err(Error::IndexOutOfBounds)
         }
     }
+    /// Read a `u64` from this reader by combining two `u32` values.
+    pub fn read_u64(&mut self) -> Result<u64, Error> {
+        let high = self.read_u32()? as u64;
+        let low = self.read_u32()? as u64;
+        Ok((high << 32) | low)
+    }
     /// Read one byte from this reader.
     pub fn read_byte(&mut self) -> Result<u8, Error> {
         if self.position < self.s.len() {

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -279,6 +279,9 @@ impl PublicKeyBase64 for key::PublicKey {
             key::PublicKey::EC { ref key } => {
                 write_ec_public_key(&mut s, key);
             }
+            key::PublicKey::Certificate(ref cert_data) => {
+                s.extend(cert_data.pubkey.public_key_bytes());
+            }
         }
         s
     }

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -134,6 +134,8 @@ pub enum Error {
     /// Index out of bounds
     #[error("Index out of bounds")]
     IndexOutOfBounds,
+    #[error("UTF-8 conversion error: {0}")]
+    Utf8Error(#[from] std::string::FromUtf8Error),
     /// Unknown signature type
     #[error("Unknown signature type: {}", sig_type)]
     UnknownSignatureType { sig_type: String },

--- a/russh/src/key.rs
+++ b/russh/src/key.rs
@@ -39,6 +39,9 @@ impl PubKey for PublicKey {
             PublicKey::EC { ref key } => {
                 write_ec_public_key(buffer, key);
             }
+            PublicKey::Certificate(ref cert_data) => {
+                cert_data.pubkey.push_to(buffer);
+            }
         }
     }
 }

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -160,6 +160,7 @@ impl Named for PublicKey {
             PublicKey::Ed25519(_) => ED25519.0,
             PublicKey::RSA { ref hash, .. } => hash.name().0,
             PublicKey::EC { ref key } => key.algorithm(),
+            PublicKey::Certificate(ref cert_data) => cert_data.pubkey.name(),
         }
     }
 }

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -476,6 +476,7 @@ impl Encrypted {
                             buf.clear();
                             buf.extend_ssh_string(session_id);
                             buf.extend(init);
+                            // Verify signature.
                             pubkey.verify_client_auth(&buf, sig)
                         }) {
                             debug!("signature verified");

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -408,9 +408,9 @@ impl Encrypted {
         let is_real = r.read_byte().map_err(crate::Error::from)?;
         let pubkey_algo = r.read_string().map_err(crate::Error::from)?;
         let pubkey_key = r.read_string().map_err(crate::Error::from)?;
-        
+
         debug!("algo: {:?}, key: {:?}", pubkey_algo, pubkey_key);
-        
+
         // Parse the public key or certificate
         match key::PublicKey::parse(pubkey_algo, pubkey_key) {
             Ok(mut pubkey) => {
@@ -425,9 +425,12 @@ impl Encrypted {
                         reject_auth_request(until, &mut self.write, auth_request).await;
                         return Ok(());
                     }
-                    
+
                     // Verify the certificate’s signature
-                    if !cert.signature_key.verify_detached(&pubkey_key, &cert.signature) {
+                    if !cert
+                        .signature_key
+                        .verify_detached(pubkey_key, &cert.signature)
+                    {
                         warn!("Certificate signature is invalid");
                         reject_auth_request(until, &mut self.write, auth_request).await;
                         return Ok(());


### PR DESCRIPTION
I added support for OpenSSH certificates to the server-side authentication. This includes:

- Certificate Parsing: A new function to parse certificate data, extracting key details like validity, key ID, and signature.

- PublicKey Enum Extension: A Certificate variant added to the PublicKey enum, representing certificate-based keys.

- Certificate Validation: Updated the authentication flow to check certificate validity and verify signatures before proceeding with authentication.

These changes enable the server to authenticate users using standard public keys and OpenSSH certificates.