### PR TITLE
Derive Debug where possible

### DIFF
--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -80,6 +80,7 @@ mod session;
 /// It is in charge of multiplexing and keeping track of various channels
 /// that may get opened and closed during the lifetime of an SSH session and
 /// allows sending messages to the server.
+#[derive(Debug)]
 pub struct Session {
     common: CommonSession<Arc<Config>>,
     receiver: Receiver<Msg>,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -127,7 +127,10 @@ impl Debug for Config {
             .field("methods", &self.methods)
             .field("auth_banner", &self.auth_banner)
             .field("auth_rejection_time", &self.auth_rejection_time)
-            .field("auth_rejection_time_initial", &self.auth_rejection_time_initial)
+            .field(
+                "auth_rejection_time_initial",
+                &self.auth_rejection_time_initial,
+            )
             .field("keys", &"***")
             .field("window_size", &self.window_size)
             .field("maximum_packet_size", &self.maximum_packet_size)

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -57,7 +57,6 @@ mod session;
 pub use self::session::*;
 mod encrypted;
 
-#[derive(Debug)]
 /// Configuration of a server.
 pub struct Config {
     /// The server ID string sent at the beginning of the protocol.
@@ -117,6 +116,29 @@ impl Default for Config {
             keepalive_interval: None,
             keepalive_max: 3,
         }
+    }
+}
+
+impl Debug for Config {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // display everything except the private keys
+        f.debug_struct("Config")
+            .field("server_id", &self.server_id)
+            .field("methods", &self.methods)
+            .field("auth_banner", &self.auth_banner)
+            .field("auth_rejection_time", &self.auth_rejection_time)
+            .field("auth_rejection_time_initial", &self.auth_rejection_time_initial)
+            .field("keys", &"***")
+            .field("window_size", &self.window_size)
+            .field("maximum_packet_size", &self.maximum_packet_size)
+            .field("event_buffer_size", &self.event_buffer_size)
+            .field("limits", &self.limits)
+            .field("preferred", &self.preferred)
+            .field("max_auth_attempts", &self.max_auth_attempts)
+            .field("inactivity_timeout", &self.inactivity_timeout)
+            .field("keepalive_interval", &self.keepalive_interval)
+            .field("keepalive_max", &self.keepalive_max)
+            .finish()
     }
 }
 

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -15,6 +15,7 @@ use crate::kex::EXTENSION_SUPPORT_AS_CLIENT;
 use crate::msg;
 
 /// A connected server session. This type is unique to a client.
+#[derive(Debug)]
 pub struct Session {
     pub(crate) common: CommonSession<Arc<Config>>,
     pub(crate) sender: Handle,
@@ -25,6 +26,7 @@ pub struct Session {
     pub(crate) channels: HashMap<ChannelId, ChannelRef>,
     pub(crate) open_global_requests: VecDeque<GlobalRequestResponse>,
 }
+
 #[derive(Debug)]
 pub enum Msg {
     ChannelOpenAgent {
@@ -82,7 +84,7 @@ impl From<(ChannelId, ChannelMsg)> for Msg {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 /// Handle to a session, used to send messages to a client outside of
 /// the request/response cycle.
 pub struct Handle {

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -53,6 +53,7 @@ pub(crate) struct Encrypted {
     pub compress_buffer: CryptoVec,
 }
 
+#[derive(Debug)]
 pub(crate) struct CommonSession<Config> {
     pub auth_user: String,
     pub remote_sshid: Vec<u8>,
@@ -655,6 +656,7 @@ pub(crate) struct NewKeys {
     pub sent: bool,
 }
 
+#[derive(Debug)]
 pub(crate) enum GlobalRequestResponse {
     /// request was for Keepalive, ignore result
     Keepalive,


### PR DESCRIPTION
I mostly wanted to `dbg!` the server's `Session`, but I took the opportunity to add `#[derive(Debug)]` wherever I could.