### PR TITLE
impl Drop for server examples

### DIFF
--- a/russh/examples/ratatui_app.rs
+++ b/russh/examples/ratatui_app.rs
@@ -208,6 +208,17 @@ impl Handler for AppServer {
     }
 }
 
+impl Drop for AppServer {
+    fn drop(&mut self) {
+        let id = self.id;
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let mut clients = clients.lock().await;
+            clients.remove(&id);
+        });
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let mut server = AppServer::new();

--- a/russh/examples/ratatui_shared_app.rs
+++ b/russh/examples/ratatui_shared_app.rs
@@ -207,6 +207,17 @@ impl Handler for AppServer {
     }
 }
 
+impl Drop for AppServer {
+    fn drop(&mut self) {
+        let id = self.id;
+        let clients = self.clients.clone();
+        tokio::spawn(async move {
+            let mut clients = clients.lock().await;
+            clients.remove(&id);
+        });
+    }
+}
+
 #[tokio::main]
 async fn main() {
     let mut server = AppServer::new();


### PR DESCRIPTION
In #373 I raised my confusion about the lack of a disconnection mechanism in the source code and the examples, but it was pointed out that `Drop` is the intended way of cleaning up resources.

This PR adds a Drop implementation for three of the server examples, so that users that refer to these won't be confused about how to implement their own cleanup.