### PR TITLE
Send proper algorithm for certificates

### DIFF
--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -177,7 +177,7 @@ impl<'a> Named<'a> for PrivateKey {
 
 impl<'a> Named<'a> for Certificate {
     fn name(&'a self) -> impl AsRef<str> + 'a {
-        self.algorithm()
+        self.algorithm().to_certificate_type()
     }
 }
 


### PR DESCRIPTION
This was preventing certificates from being detected as such by the server.

Fixed #375 