### PR TITLE
Add support for StrictHostKeyChecking and UserKnownHostsFile

### DIFF
--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -142,7 +142,10 @@ pub fn parse(file: &str, host: &str) -> Result<Config, Error> {
                         }
                     }
                     "identityfile" => {
-                        let id = value.trim_start();
+                        let mut id = value.trim_start();
+                        if id.len() > 1 && id.starts_with('\'') && id.ends_with('\'') {
+                            id = &id[1..id.len() - 1];
+                        }
                         if id.starts_with("~/") {
                             if let Some(mut home) = home::home_dir() {
                                 home.push(id.split_at(2).1);
@@ -172,7 +175,10 @@ pub fn parse(file: &str, host: &str) -> Result<Config, Error> {
                         _ => config.add_keys_to_agent = AddKeysToAgent::No,
                     },
                     "userknownhostsfile" => {
-                        let id = value.trim_start();
+                        let mut id = value.trim_start();
+                        if id.len() > 1 && id.starts_with('\'') && id.ends_with('\'') {
+                            id = &id[1..id.len() - 1];
+                        }
                         if id.starts_with("~/") {
                             if let Some(mut home) = home::home_dir() {
                                 home.push(id.split_at(2).1);


### PR DESCRIPTION
As I realize I use StrictHostKeyChecking and UserKnownHostsFile in some of my .ssh/config files, I have added support for them in russh-config. 