### PR TITLE
Expose authenticated username for session

### DIFF
--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -736,6 +736,12 @@ impl Session {
         &self.common.config
     }
 
+    /// Retrieves the authenticated user associated with this session.
+    /// In case of successful `auth_none`, username is empty ("")
+    pub fn username(&self) -> &str {
+        &self.common.auth_user
+    }
+
     /// Sends a disconnect message.
     pub fn disconnect(
         &mut self,


### PR DESCRIPTION
- this allows to modify sftp server behaviour depending on logged user