### PR TITLE
Add option to directly load openssh private key file in pem format

### DIFF
--- a/russh-keys/src/format/openssh.rs
+++ b/russh-keys/src/format/openssh.rs
@@ -15,3 +15,26 @@ pub fn decode_openssh(secret: &[u8], password: Option<&str>) -> Result<PrivateKe
     }
     Ok(pk)
 }
+
+/// Parse a private key given in the OpenSSH PEM format, deciphering it if
+/// needed using the supplied password.
+///
+/// OpenSSH-formatted private keys begin with the following:
+///
+/// ```text
+/// -----BEGIN OPENSSH PRIVATE KEY-----
+/// ```
+pub fn parse_openssh_pem(
+    pem: impl AsRef<[u8]>,
+    password: Option<&str>,
+) -> Result<PrivateKey, Error> {
+    let pk = PrivateKey::from_openssh(pem)?;
+    if pk.is_encrypted() {
+        if let Some(password) = password {
+            return Ok(pk.decrypt(password)?);
+        } else {
+            return Err(Error::KeyIsEncrypted);
+        }
+    }
+    Ok(pk)
+}


### PR DESCRIPTION
- although this can be done manually, it's just more convenient to have it out-of-the-box