### PR TITLE
Fix improper RSA key conversion from `ssh_key` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ futures = "0.3"
 hmac = "0.12"
 log = "0.4"
 rand = "0.8"
-rsa = "0.9"
+rsa = "=0.9.6"
 sha1 = { version = "0.10", features = ["oid"] }
 sha2 = { version = "0.10", features = ["oid"] }
 signature = "2.2"

--- a/cryptovec/src/platform/mod.rs
+++ b/cryptovec/src/platform/mod.rs
@@ -19,18 +19,16 @@ pub use windows::{memset, mlock, munlock};
 
 #[cfg(test)]
 mod tests {
-    use wasm_bindgen_test::wasm_bindgen_test;
-
     use super::*;
 
-    #[wasm_bindgen_test]
+    #[test]
     fn test_memset() {
         let mut buf = vec![0u8; 10];
         memset(buf.as_mut_ptr(), 0xff, buf.len());
         assert_eq!(buf, vec![0xff; 10]);
     }
 
-    #[wasm_bindgen_test]
+    #[test]
     fn test_memset_partial() {
         let mut buf = vec![0u8; 10];
         memset(buf.as_mut_ptr(), 0xff, 5);

--- a/russh-keys/src/helpers.rs
+++ b/russh-keys/src/helpers.rs
@@ -62,7 +62,7 @@ pub fn sign_workaround(
             )?;
             let signature = signature::Signer::try_sign(
                 &rsa::pkcs1v15::SigningKey::<sha2::Sha512>::new(pk),
-                &data,
+                data,
             )?;
             ssh_key::Signature::new(
                 ssh_key::Algorithm::Rsa {
@@ -71,6 +71,6 @@ pub fn sign_workaround(
                 <rsa::pkcs1v15::Signature as signature::SignatureEncoding>::to_vec(&signature),
             )?
         }
-        keypair => signature::Signer::try_sign(keypair, &data)?,
+        keypair => signature::Signer::try_sign(keypair, data)?,
     })
 }

--- a/russh-keys/src/helpers.rs
+++ b/russh-keys/src/helpers.rs
@@ -41,3 +41,36 @@ macro_rules! map_err {
 }
 
 pub use map_err;
+use ssh_key::PrivateKey;
+
+// TODO only needed until https://github.com/RustCrypto/SSH/pull/318 is released
+#[doc(hidden)]
+pub fn sign_workaround(
+    key: &PrivateKey,
+    data: &[u8],
+) -> Result<ssh_key::Signature, signature::Error> {
+    Ok(match key.key_data() {
+        ssh_key::private::KeypairData::Rsa(rsa_keypair) => {
+            let pk = rsa::RsaPrivateKey::from_components(
+                <rsa::BigUint as std::convert::TryFrom<_>>::try_from(&rsa_keypair.public.n)?,
+                <rsa::BigUint as std::convert::TryFrom<_>>::try_from(&rsa_keypair.public.e)?,
+                <rsa::BigUint as std::convert::TryFrom<_>>::try_from(&rsa_keypair.private.d)?,
+                vec![
+                    <rsa::BigUint as std::convert::TryFrom<_>>::try_from(&rsa_keypair.private.p)?,
+                    <rsa::BigUint as std::convert::TryFrom<_>>::try_from(&rsa_keypair.private.q)?,
+                ],
+            )?;
+            let signature = signature::Signer::try_sign(
+                &rsa::pkcs1v15::SigningKey::<sha2::Sha512>::new(pk),
+                &data,
+            )?;
+            ssh_key::Signature::new(
+                ssh_key::Algorithm::Rsa {
+                    hash: Some(ssh_key::HashAlg::Sha512),
+                },
+                <rsa::pkcs1v15::Signature as signature::SignatureEncoding>::to_vec(&signature),
+            )?
+        }
+        keypair => signature::Signer::try_sign(keypair, &data)?,
+    })
+}

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -857,7 +857,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         client.request_identities().await?;
         let buf = russh_cryptovec::CryptoVec::from_slice(b"blabla");
         let len = buf.len();
-        let buf = client.sign_request(&public, buf).await.unwrap();
+        let buf = client.sign_request(public, buf).await.unwrap();
         let (a, b) = buf.split_at(len);
 
         match key.public_key().key_data() {
@@ -943,7 +943,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
             client.request_identities().await.unwrap();
             let buf = russh_cryptovec::CryptoVec::from_slice(b"blabla");
             let len = buf.len();
-            let buf = client.sign_request(&public, buf).await.unwrap();
+            let buf = client.sign_request(public, buf).await.unwrap();
             let (a, b) = buf.split_at(len);
             if let ssh_key::public::KeyData::Ed25519 { .. } = public.key_data() {
                 let sig = &b[b.len() - 64..];

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -82,6 +82,10 @@ pub mod helpers;
 pub use format::*;
 pub use ssh_key::{self, Algorithm, Certificate, EcdsaCurve, HashAlg, PrivateKey, PublicKey};
 
+// Reexports
+pub use signature;
+pub use ssh_encoding;
+
 /// OpenSSH agent protocol implementation
 pub mod agent;
 

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
-version = "0.47.0-beta.2"
+version = "0.47.0-beta.3"
 rust-version = "1.65"
 
 [features]

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -1049,7 +1049,7 @@ impl Encrypted {
                 )?;
 
                 // Extend with self-signature.
-                let signature = sign_workaround(&**key, buffer)?;
+                let signature = sign_workaround(key, buffer)?;
                 signature.encoded()?.encode(&mut *buffer)?;
 
                 push_packet!(self.write, {
@@ -1065,7 +1065,7 @@ impl Encrypted {
                 )?;
 
                 // Extend with self-signature.
-                let signature = sign_workaround(&**key, buffer)?;
+                let signature = sign_workaround(key, buffer)?;
                 signature.encoded()?.encode(&mut *buffer)?;
 
                 push_packet!(self.write, {

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -18,7 +18,7 @@ use std::num::Wrapping;
 
 use bytes::Bytes;
 use log::{debug, error, info, trace, warn};
-use russh_keys::helpers::{map_err, EncodedExt};
+use russh_keys::helpers::{map_err, sign_workaround, EncodedExt};
 use ssh_encoding::{Decode, Encode};
 
 use crate::cert::PublicKeyOrCertificate;
@@ -1049,7 +1049,7 @@ impl Encrypted {
                 )?;
 
                 // Extend with self-signature.
-                let signature = signature::Signer::try_sign(&**key, buffer)?;
+                let signature = sign_workaround(&**key, buffer)?;
                 signature.encoded()?.encode(&mut *buffer)?;
 
                 push_packet!(self.write, {
@@ -1065,7 +1065,7 @@ impl Encrypted {
                 )?;
 
                 // Extend with self-signature.
-                let signature = signature::Signer::try_sign(&**key, buffer)?;
+                let signature = sign_workaround(&**key, buffer)?;
                 signature.encoded()?.encode(&mut *buffer)?;
 
                 push_packet!(self.write, {

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::ops::DerefMut;
 
 use log::debug;
-use russh_keys::helpers::EncodedExt;
+use russh_keys::helpers::{sign_workaround, EncodedExt};
 use ssh_encoding::Encode;
 
 use super::*;
@@ -145,7 +145,7 @@ impl KexDh {
                 debug!("hash: {:?}", hash);
                 debug!("key: {:?}", config.keys[kexdhdone.key]);
 
-                let signature = signature::Signer::try_sign(&config.keys[kexdhdone.key], &hash)?;
+                let signature = sign_workaround(&config.keys[kexdhdone.key], &hash)?;
                 signature.encoded()?.encode(&mut *buffer)?;
 
                 cipher.write(&buffer, write_buffer);


### PR DESCRIPTION
`rsa` 0.9.7 introduces an error when using a key to sign (likely due to overeager validation during conversion). You can see the changes here: https://diff.rs/rsa/0.9.6/0.9.7/

This commit fixes the version back to 0.9.6 as a quick fix, although this may not be the desired solution.