### PR TITLE
Attempt to remove busywait in ChannelTx

### DIFF
--- a/russh/src/channels/channel_ref.rs
+++ b/russh/src/channels/channel_ref.rs
@@ -3,14 +3,14 @@ use std::sync::Arc;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::Mutex;
 
-use crate::ChannelMsg;
+use crate::{channels::WindowSize, ChannelMsg};
 
 /// A handle to the [`super::Channel`]'s to be able to transmit messages
 /// to it and update it's `window_size`.
 #[derive(Debug)]
 pub struct ChannelRef {
     pub(super) sender: UnboundedSender<ChannelMsg>,
-    pub(super) window_size: Arc<Mutex<u32>>,
+    pub(super) window_size: Arc<Mutex<WindowSize>>,
 }
 
 impl ChannelRef {
@@ -21,7 +21,7 @@ impl ChannelRef {
         }
     }
 
-    pub fn window_size(&self) -> &Arc<Mutex<u32>> {
+    pub(crate) fn window_size(&self) -> &Arc<Mutex<WindowSize>> {
         &self.window_size
     }
 }

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -630,7 +630,7 @@ impl Session {
                     new_size -= enc.flush_pending(channel_num)? as u32;
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
-                    *chan.window_size().lock().await = new_size;
+                    chan.window_size().lock().await.set(new_size);
 
                     let _ = chan.send(ChannelMsg::WindowAdjusted { new_size });
                 }

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -56,7 +56,7 @@ use tokio::sync::mpsc::{
 };
 use tokio::sync::{oneshot, Mutex};
 
-use crate::channels::{Channel, ChannelMsg, ChannelRef};
+use crate::channels::{Channel, ChannelMsg, ChannelRef, WindowSize};
 use crate::cipher::{self, clear, CipherPair, OpeningKey};
 use crate::keys::key::parse_public_key;
 use crate::session::{
@@ -428,7 +428,7 @@ impl<H: Handler> Handle<H> {
     async fn wait_channel_confirmation(
         &self,
         mut receiver: UnboundedReceiver<ChannelMsg>,
-        window_size_ref: Arc<Mutex<u32>>,
+        window_size_ref: Arc<Mutex<WindowSize>>,
     ) -> Result<Channel<Msg>, crate::Error> {
         loop {
             match receiver.recv().await {
@@ -437,7 +437,7 @@ impl<H: Handler> Handle<H> {
                     max_packet_size,
                     window_size,
                 }) => {
-                    *window_size_ref.lock().await = window_size;
+                    window_size_ref.lock().await.set(window_size);
 
                     return Ok(Channel {
                         id,

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -763,7 +763,7 @@ impl Session {
                     enc.flush_pending(channel_num)?;
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
-                    *chan.window_size().lock().await = new_size;
+                    chan.window_size().lock().await.set(new_size);
 
                     chan.send(ChannelMsg::WindowAdjusted { new_size })
                         .unwrap_or(())

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc::{unbounded_channel, Receiver, Sender, UnboundedReceiver};
 use tokio::sync::{oneshot, Mutex};
 
 use super::*;
-use crate::channels::{Channel, ChannelMsg, ChannelRef};
+use crate::channels::{Channel, ChannelMsg, ChannelRef, WindowSize};
 use crate::kex::EXTENSION_SUPPORT_AS_CLIENT;
 use crate::msg;
 
@@ -346,7 +346,7 @@ impl Handle {
     async fn wait_channel_confirmation(
         &self,
         mut receiver: UnboundedReceiver<ChannelMsg>,
-        window_size_ref: Arc<Mutex<u32>>,
+        window_size_ref: Arc<Mutex<WindowSize>>,
     ) -> Result<Channel<Msg>, Error> {
         loop {
             match receiver.recv().await {
@@ -355,7 +355,7 @@ impl Handle {
                     max_packet_size,
                     window_size,
                 }) => {
-                    *window_size_ref.lock().await = window_size;
+                    window_size_ref.lock().await.set(window_size);
 
                     return Ok(Channel {
                         id,


### PR DESCRIPTION
Some progress on #401. This passes the `poll_mk_msg` waker along with the window size in order to avoid busy-waiting for changes. This is currently untested, hence the draft PR.