### PR TITLE
Add `authentication_banner` method to server::Handler

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -181,7 +181,7 @@ impl Session {
                 debug!("request: {:?}", request);
                 if request == "ssh-userauth" {
                     let auth_request = server_accept_service(
-                        self.common.config.as_ref().auth_banner,
+                        handler.authentication_banner().await?,
                         self.common.config.as_ref().methods,
                         &mut enc.write,
                     )?;
@@ -242,7 +242,7 @@ impl Session {
 }
 
 fn server_accept_service(
-    banner: Option<&str>,
+    banner: Option<String>,
     methods: MethodSet,
     buffer: &mut CryptoVec,
 ) -> Result<AuthRequest, crate::Error> {

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -63,8 +63,6 @@ pub struct Config {
     pub server_id: SshId,
     /// Authentication methods proposed to the client.
     pub methods: auth::MethodSet,
-    /// The authentication banner, usually a warning message shown to the client.
-    pub auth_banner: Option<&'static str>,
     /// Authentication rejections must happen in constant time for
     /// security reasons. Russh does not handle this by default.
     pub auth_rejection_time: std::time::Duration,
@@ -104,7 +102,6 @@ impl Default for Config {
                 env!("CARGO_PKG_VERSION")
             )),
             methods: auth::MethodSet::all(),
-            auth_banner: None,
             auth_rejection_time: std::time::Duration::from_secs(1),
             auth_rejection_time_initial: None,
             keys: Vec::new(),
@@ -128,7 +125,6 @@ impl Debug for Config {
         f.debug_struct("Config")
             .field("server_id", &self.server_id)
             .field("methods", &self.methods)
-            .field("auth_banner", &self.auth_banner)
             .field("auth_rejection_time", &self.auth_rejection_time)
             .field(
                 "auth_rejection_time_initial",
@@ -287,6 +283,13 @@ pub trait Handler: Sized {
     #[allow(unused_variables)]
     async fn auth_succeeded(&mut self, session: &mut Session) -> Result<(), Self::Error> {
         Ok(())
+    }
+
+    /// Called when authentication starts but before it is successful.
+    /// Return value is an authentication banner, usually a warning message shown to the client.
+    #[allow(unused_variables)]
+    async fn authentication_banner(&mut self) -> Result<Option<String>, Self::Error> {
+        Ok(None)
     }
 
     /// Called when the client closes a channel.


### PR DESCRIPTION
This replaces the configuration option `auth_banner`, making this a breaking change.

Closes #372.