### PR TITLE
bump patch version of dependency `ssh-key`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ sha1 = { version = "0.10", features = ["oid"] }
 sha2 = { version = "0.10", features = ["oid"] }
 signature = "2.2"
 ssh-encoding = { version = "0.2", features = ["bytes"] }
-ssh-key = { version = "0.6", features = [
+ssh-key = { version = "0.6.2", features = [
     "ed25519",
     "rsa",
     "p256",


### PR DESCRIPTION
The feature `p521` doesn't exist in versions of `ssh-key` older than 0.6.2.

This causes build failures if `russh` is introduced into a cargo workspace that already contains a dependency on e.g. `ssh-key 0.6.0`; since nothing in the `russh` `Cargo.toml` was specifying an update was required Cargo does not know to update to a newer version.