### PR TITLE
replace tempdir with tempfile

### DIFF
--- a/russh-keys/Cargo.toml
+++ b/russh-keys/Cargo.toml
@@ -82,5 +82,5 @@ pageant = { version = "0.0.1-beta.3", path = "../pageant" }
 
 [dev-dependencies]
 env_logger = "0.11"
-tempdir = "0.3"
+tempfile = "3.14.0"
 tokio = { workspace = true, features = ["test-util", "macros", "process"] }

--- a/russh-keys/src/known_hosts.rs
+++ b/russh-keys/src/known_hosts.rs
@@ -194,7 +194,7 @@ mod test {
     #[test]
     fn test_check_known_hosts() {
         env_logger::try_init().unwrap_or(());
-        let dir = tempdir::TempDir::new("russh").unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("known_hosts");
         {
             let mut f = File::create(&path).unwrap();

--- a/russh-keys/src/lib.rs
+++ b/russh-keys/src/lib.rs
@@ -33,7 +33,7 @@
 //! #[cfg(unix)]
 //! fn main() {
 //!    env_logger::try_init().unwrap_or(());
-//!    let dir = tempdir::TempDir::new("russh").unwrap();
+//!    let dir = tempfile::tempdir().unwrap();
 //!    let agent_path = dir.path().join("agent");
 //!
 //!    let mut core = tokio::runtime::Runtime::new().unwrap();
@@ -834,7 +834,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         env_logger::try_init().unwrap_or(());
         use std::process::Stdio;
 
-        let dir = tempdir::TempDir::new("russh")?;
+        let dir = tempfile::tempdir()?;
         let agent_path = dir.path().join("agent");
         let mut agent = tokio::process::Command::new("ssh-agent")
             .arg("-a")
@@ -901,7 +901,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
     #[cfg(unix)]
     fn test_agent() {
         env_logger::try_init().unwrap_or(());
-        let dir = tempdir::TempDir::new("russh").unwrap();
+        let dir = tempfile::tempdir().unwrap();
         let agent_path = dir.path().join("agent");
 
         let core = tokio::runtime::Runtime::new().unwrap();


### PR DESCRIPTION
`tempdir` has been abandoned, last published 6 years ago. (RUSTSEC-2018-0017). And some of its dependencies have known security issues (RUSTSEC-2023-0018).

The recommended replacement is the `tempfile` crate.

Most uses of `tempdir` were in tests, but one was in the example in `russh-keys`-- it's probably not a good idea for examples to include code that would bring in dependencies with security issues.

This resolves two advisories reported by `cargo-deny`. It might be a good idea to run `cargo deny` periodically to catch issues with dependencies (probably not on the PR path since it will spontaneously start failing when a new advisory lands).