### PR TITLE
feature-gate `des` dependency

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -15,6 +15,8 @@ rust-version = "1.65"
 [features]
 default = ["flate2"]
 legacy-ed25519-pkcs8-parser = ["russh-keys/legacy-ed25519-pkcs8-parser"]
+# Danger: 3DES cipher is insecure.
+des = ["dep:des"]
 
 [dependencies]
 aes.workspace = true
@@ -55,7 +57,7 @@ ssh-key.workspace = true
 subtle = "2.4"
 thiserror.workspace = true
 russh-util = { version = "0.48.0", path = "../russh-util" }
-des = "0.8.1"
+des = { version = "0.8.1", optional = true }
 tokio = { workspace = true, features = ["io-util", "sync", "time"] }
 
 [dev-dependencies]

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -26,7 +26,6 @@ use byteorder::{BigEndian, ByteOrder};
 use cbc::CbcWrapper;
 use ctr::Ctr128BE;
 use delegate::delegate;
-use des::TdesEde3;
 use log::debug;
 use once_cell::sync::Lazy;
 use ssh_encoding::Encode;
@@ -74,6 +73,7 @@ pub(crate) trait Cipher {
 /// `clear`
 pub const CLEAR: Name = Name("clear");
 /// `3des-cbc`
+#[cfg(feature = "des")]
 pub const TRIPLE_DES_CBC: Name = Name("3des-cbc");
 /// `aes128-ctr`
 pub const AES_128_CTR: Name = Name("aes128-ctr");
@@ -95,7 +95,8 @@ pub const CHACHA20_POLY1305: Name = Name("chacha20-poly1305@openssh.com");
 pub const NONE: Name = Name("none");
 
 static _CLEAR: Clear = Clear {};
-static _3DES_CBC: SshBlockCipher<CbcWrapper<TdesEde3>> = SshBlockCipher(PhantomData);
+#[cfg(feature = "des")]
+static _3DES_CBC: SshBlockCipher<CbcWrapper<des::TdesEde3>> = SshBlockCipher(PhantomData);
 static _AES_128_CTR: SshBlockCipher<Ctr128BE<Aes128>> = SshBlockCipher(PhantomData);
 static _AES_192_CTR: SshBlockCipher<Ctr128BE<Aes192>> = SshBlockCipher(PhantomData);
 static _AES_256_CTR: SshBlockCipher<Ctr128BE<Aes256>> = SshBlockCipher(PhantomData);
@@ -108,6 +109,7 @@ static _CHACHA20_POLY1305: SshChacha20Poly1305Cipher = SshChacha20Poly1305Cipher
 pub static ALL_CIPHERS: &[&Name] = &[
     &CLEAR,
     &NONE,
+    #[cfg(feature = "des")]
     &TRIPLE_DES_CBC,
     &AES_128_CTR,
     &AES_192_CTR,
@@ -124,6 +126,7 @@ pub(crate) static CIPHERS: Lazy<HashMap<&'static Name, &(dyn Cipher + Send + Syn
         let mut h: HashMap<&'static Name, &(dyn Cipher + Send + Sync)> = HashMap::new();
         h.insert(&CLEAR, &_CLEAR);
         h.insert(&NONE, &_CLEAR);
+        #[cfg(feature = "des")]
         h.insert(&TRIPLE_DES_CBC, &_3DES_CBC);
         h.insert(&AES_128_CTR, &_AES_128_CTR);
         h.insert(&AES_192_CTR, &_AES_192_CTR);


### PR DESCRIPTION
Move the `des` dependency behind a cargo feature that is disabled by default, both to avoid security concerns about dependencies (an auditor may not know which ciphers are enabled at runtime), as well as reduce the number of dependencies downstream projects need to build.

This addresses one of the issues in #420.