### PR TITLE
bump dependency versions to the minimum version that compiles.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,3 +80,14 @@ jobs:
         cargo test --verbose --all-features
       env:
         RUST_BACKTRACE: 1
+
+  Minimal-versions:
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: taiki-e/install-action@cargo-hack
+    - uses: taiki-e/install-action@cargo-minimal-versions
+
+    - name: Check with minimal dependency versions
+      run: cargo minimal-versions check --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ resolver = "2"
 
 [workspace.dependencies]
 aes = "0.8"
-async-trait = "0.1"
+async-trait = "0.1.50"
 byteorder = "1.4"
 bytes = "1.7"
 digest = "0.10"
@@ -21,11 +21,11 @@ hmac = "0.12"
 log = "0.4"
 rand = "0.8"
 rsa = "0.9"
-sha1 = { version = "0.10", features = ["oid"] }
-sha2 = { version = "0.10", features = ["oid"] }
+sha1 = { version = "0.10.5", features = ["oid"] }
+sha2 = { version = "0.10.6", features = ["oid"] }
 signature = "2.2"
 ssh-encoding = { version = "0.2", features = ["bytes"] }
-ssh-key = { version = "0.6", features = [
+ssh-key = { version = "0.6.3", features = [
     "ed25519",
     "rsa",
     "p256",
@@ -33,6 +33,6 @@ ssh-key = { version = "0.6", features = [
     "p521",
     "encryption",
 ] }
-thiserror = "1.0"
-tokio = { version = "1.17.0" }
-tokio-stream = { version = "0.1", features = ["net", "sync"] }
+thiserror = "1.0.30"
+tokio = { version = "1.40.0" }
+tokio-stream = { version = "0.1.3", features = ["net", "sync"] }

--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -17,7 +17,7 @@ ssh-encoding = { workspace = true, optional = true }
 winapi = {version = "0.3", features = ["basetsd", "minwindef", "memoryapi"]}
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3"
+wasm-bindgen-test = "0.3.46"
 
 [features]
 ssh-encoding = ["dep:ssh-encoding"]

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -32,13 +32,13 @@ curve25519-dalek = "4.1.3"
 delegate.workspace = true
 digest.workspace = true
 elliptic-curve = { version = "0.13", features = ["ecdh"] }
-flate2 = { version = "1.0", optional = true }
+flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
 generic-array = "0.14"
 hex-literal = "0.4"
 hmac.workspace = true
 log.workspace = true
-num-bigint = { version = "0.4", features = ["rand"] }
+num-bigint = { version = "0.4.2", features = ["rand"] }
 once_cell = "1.13"
 p256 = { version = "0.13", features = ["ecdh"] }
 p384 = { version = "0.13", features = ["ecdh"] }
@@ -61,9 +61,9 @@ des = { version = "0.8.1", optional = true }
 tokio = { workspace = true, features = ["io-util", "sync", "time"] }
 
 [dev-dependencies]
-anyhow = "1.0"
+anyhow = "1.0.4"
 env_logger = "0.11"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "3.2.3", features = ["derive"] }
 tokio = { version = "1.17.0", features = [
     "io-std",
     "io-util",


### PR DESCRIPTION
The dependency versions in Cargo.toml were inaccurate in places, because they allowed versions that don't actually work-- crates were enabling Cargo features that don't exist in those versions, or methods/traits/etc that didn't exist in the code.

This allows a tool like `cargo minimal-versions` to verify that the code compiles even when using the oldest possible dependency versions, but is also a useful step toward verifying that the crates can be built on older toolchains.

Replaces #419.
