### PR TITLE
Add an option to enable TCP_NODELAY

### DIFF
--- a/russh/examples/ratatui_app.rs
+++ b/russh/examples/ratatui_app.rs
@@ -123,6 +123,7 @@ impl AppServer {
             keys: vec![
                 russh_keys::PrivateKey::random(&mut OsRng, ssh_key::Algorithm::Ed25519).unwrap(),
             ],
+            nodelay: true,
             ..Default::default()
         };
 

--- a/russh/examples/ratatui_shared_app.rs
+++ b/russh/examples/ratatui_shared_app.rs
@@ -125,6 +125,7 @@ impl AppServer {
             keys: vec![
                 russh_keys::PrivateKey::random(&mut OsRng, ssh_key::Algorithm::Ed25519).unwrap(),
             ],
+            nodelay: true,
             ..Default::default()
         };
 


### PR DESCRIPTION
This commit adds a new configuration option, `nodelay` - activating this option disables Nagle's algorithm for client sockets.

## Motivation

While working on [a game of mine](https://github.com/Patryk27/kartoffels) I realized that the version deployed online seems to have a noticeable lag - it didn't took long to piece two and two, and realize that Nagle's at fault. I have confirmed that calling `set_nodelay()` solves the issue on my side.