### PR TITLE
Allow setting hash algorithm to use for signing requests of SSH agent

### DIFF
--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use ssh_key::{Certificate, PrivateKey};
+use ssh_key::{Certificate, HashAlg, PrivateKey};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 
@@ -154,6 +154,7 @@ pub trait Signer: Sized {
     async fn auth_publickey_sign(
         &mut self,
         key: &ssh_key::PublicKey,
+        hash_alg: Option<HashAlg>,
         to_sign: CryptoVec,
     ) -> Result<CryptoVec, Self::Error>;
 }
@@ -175,9 +176,12 @@ impl<R: AsyncRead + AsyncWrite + Unpin + Send + 'static> Signer
     async fn auth_publickey_sign(
         &mut self,
         key: &ssh_key::PublicKey,
+        hash_alg: Option<HashAlg>,
         to_sign: CryptoVec,
     ) -> Result<CryptoVec, Self::Error> {
-        self.sign_request(key, to_sign).await.map_err(Into::into)
+        self.sign_request(key, hash_alg, to_sign)
+            .await
+            .map_err(Into::into)
     }
 }
 

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -47,7 +47,7 @@ use kex::ClientKex;
 use log::{debug, error, trace};
 use russh_util::time::Instant;
 use ssh_encoding::Decode;
-use ssh_key::{Certificate, PrivateKey, PublicKey};
+use ssh_key::{Certificate, HashAlg, PrivateKey, PublicKey};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::pin;
 use tokio::sync::mpsc::{
@@ -401,6 +401,7 @@ impl<H: Handler> Handle<H> {
         &mut self,
         user: U,
         key: ssh_key::PublicKey,
+        hash_alg: Option<HashAlg>,
         signer: &mut S,
     ) -> Result<AuthResult, S::Error> {
         let user = user.into();
@@ -423,7 +424,7 @@ impl<H: Handler> Handle<H> {
                     proceed_with_methods: remaining_methods,
                 }) => return Ok(AuthResult::Failure { remaining_methods }),
                 Some(Reply::SignRequest { key, data }) => {
-                    let data = signer.auth_publickey_sign(&key, data).await;
+                    let data = signer.auth_publickey_sign(&key, hash_alg, data).await;
                     let data = match data {
                         Ok(data) => data,
                         Err(e) => return Err(e),

--- a/russh/src/keys/mod.rs
+++ b/russh/src/keys/mod.rs
@@ -45,7 +45,7 @@
 //!        client.add_identity(&key, &[agent::Constraint::KeyLifetime { seconds: 60 }]).await?;
 //!        client.request_identities().await?;
 //!        let buf = b"signed message";
-//!        let sig = client.sign_request(&public, russh_cryptovec::CryptoVec::from_slice(&buf[..])).await.unwrap();
+//!        let sig = client.sign_request(&public, None, russh_cryptovec::CryptoVec::from_slice(&buf[..])).await.unwrap();
 //!        // Here, `sig` is encoded in a format usable internally by the SSH protocol.
 //!        Ok::<(), Error>(())
 //!    }).unwrap()
@@ -849,7 +849,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         client.request_identities().await?;
         let buf = russh_cryptovec::CryptoVec::from_slice(b"blabla");
         let len = buf.len();
-        let buf = client.sign_request(public, buf).await.unwrap();
+        let buf = client.sign_request(public, None, buf).await.unwrap();
         let (a, b) = buf.split_at(len);
 
         match key.public_key().key_data() {
@@ -935,7 +935,7 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
             client.request_identities().await.unwrap();
             let buf = russh_cryptovec::CryptoVec::from_slice(b"blabla");
             let len = buf.len();
-            let buf = client.sign_request(public, buf).await.unwrap();
+            let buf = client.sign_request(public, None, buf).await.unwrap();
             let (a, b) = buf.split_at(len);
             if let ssh_key::public::KeyData::Ed25519 { .. } = public.key_data() {
                 let sig = &b[b.len() - 64..];


### PR DESCRIPTION
This is a suggestion PR that I've tested locally. I'm happy to adjust it in any way you see fit.

@nightmared would it be possible for you to test it, too? (just like in the ticket you've described).

Fixes: https://github.com/Eugeny/russh/issues/444
Fixes: https://github.com/Eugeny/russh/issues/445

Note that since I'm using my own agent server implementation and upstream ssh-key has not released a version with some critical fixes such as https://github.com/RustCrypto/SSH/pull/263 making signatures with SHA-1 is totally broken :( so I'd be really happy if something like this has been merged. Thanks for your time! :bow: 