### PR TITLE
Add a function to send ExitStatus message to Channel

### DIFF
--- a/russh/src/channels/mod.rs
+++ b/russh/src/channels/mod.rs
@@ -340,6 +340,10 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
         self.send_msg(ChannelMsg::Eof).await
     }
 
+    pub async fn exit_status(&self, exit_status: u32) -> Result<(), Error> {
+        self.send_msg(ChannelMsg::ExitStatus { exit_status }).await
+    }
+
     /// Request that the channel be closed.
     pub async fn close(&self) -> Result<(), Error> {
         self.send_msg(ChannelMsg::Close).await


### PR DESCRIPTION
This is a non-breaking change which adds a way to send ExitStatus over a channel. This makes it possible to write simple command/shell handlers which consume a Channel<Msg> and perform some shell interaction. Such handlers can then be spawned in response to an `exec_request` or `shell_request`.

Using the &mut Session to try and send the ExitStatus message instead is not easy for longer living interactions (that don't immediately return).