### PR TITLE
Cryptovec/Windows: Add reference counting per Page, improve error-msg

### DIFF
--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -15,7 +15,14 @@ ssh-encoding = { workspace = true, optional = true }
 log.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = {version = "0.3", features = ["basetsd", "minwindef", "memoryapi"]}
+winapi = { version = "0.3", features = [
+    "basetsd",
+    "minwindef",
+    "memoryapi",
+    "errhandlingapi",
+    "sysinfoapi",
+    "impl-default",
+] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.46"

--- a/cryptovec/src/platform/windows.rs
+++ b/cryptovec/src/platform/windows.rs
@@ -1,24 +1,99 @@
-use libc::c_void;
+use std::ffi::c_void;
+use std::sync::{Mutex, OnceLock};
 use winapi::shared::basetsd::SIZE_T;
 use winapi::shared::minwindef::LPVOID;
+use winapi::um::errhandlingapi::GetLastError;
 use winapi::um::memoryapi::{VirtualLock, VirtualUnlock};
+use winapi::um::sysinfoapi::{GetNativeSystemInfo, SYSTEM_INFO};
 
 use super::MemoryLockError;
 
+// To correctly lock/unlock memory, we need to know the pagesize:
+static PAGE_SIZE: OnceLock<usize> = OnceLock::new();
+// Store refcounters for all locked pages, since Windows doesn't handle that for us:
+static LOCKED_PAGES: Mutex<Vec<PageLock>> = Mutex::new(Vec::new());
+
+struct PageLock {
+    page_idx: usize,
+    lock_counter: usize,
+}
+
 /// Unlock memory on drop for Windows.
 pub fn munlock(ptr: *const u8, len: usize) -> Result<(), MemoryLockError> {
+    let page_indices = get_page_indices(ptr, len);
+    let mut locked_pages = LOCKED_PAGES
+        .lock()
+        .map_err(|e| MemoryLockError::new(format!("Accessing PageLocks failed: {e}")))?;
+    for page_idx in page_indices {
+        match locked_pages.binary_search_by_key(&page_idx, |pl| pl.page_idx) {
+            Ok(vec_idx) => {
+                #[allow(clippy::indexing_slicing)] // binary_search Ok() is always valid index
+                {
+                    locked_pages[vec_idx].lock_counter -= 1;
+                    if locked_pages[vec_idx].lock_counter == 0 {
+                        locked_pages.remove(vec_idx);
+                        unlock_page(page_idx)?;
+                    }
+                }
+            }
+            Err(_) => {
+                return Err(MemoryLockError::new(
+                    "Tried to unlock pointer from non-locked page!".into(),
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+
+fn unlock_page(page_idx: usize) -> Result<(), MemoryLockError> {
     unsafe {
-        if VirtualUnlock(ptr as LPVOID, len as SIZE_T) == 0 {
-            return Err(MemoryLockError::new("VirtualUnlock".into()));
+        if VirtualUnlock((page_idx * get_page_size()) as LPVOID, 1 as SIZE_T) == 0 {
+            // codes can be looked up at https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes
+            let errorcode = GetLastError();
+            return Err(MemoryLockError::new(format!(
+                "VirtualUnlock: 0x{errorcode:x}"
+            )));
         }
     }
     Ok(())
 }
 
 pub fn mlock(ptr: *const u8, len: usize) -> Result<(), MemoryLockError> {
+    let page_indices = get_page_indices(ptr, len);
+    let mut locked_pages = LOCKED_PAGES
+        .lock()
+        .map_err(|e| MemoryLockError::new(format!("Accessing PageLocks failed: {e}")))?;
+    for page_idx in page_indices {
+        match locked_pages.binary_search_by_key(&page_idx, |pl| pl.page_idx) {
+            Ok(vec_idx) => {
+                #[allow(clippy::indexing_slicing)] // binary_search Ok() is always valid index
+                {
+                    locked_pages[vec_idx].lock_counter += 1;
+                }
+            }
+            Err(vec_idx) => {
+                lock_page(page_idx)?;
+                locked_pages.insert(
+                    vec_idx,
+                    PageLock {
+                        page_idx,
+                        lock_counter: 1,
+                    },
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn lock_page(page_idx: usize) -> Result<(), MemoryLockError> {
     unsafe {
-        if VirtualLock(ptr as LPVOID, len as SIZE_T) == 0 {
-            return Err(MemoryLockError::new("VirtualLock".into()));
+        if VirtualLock((page_idx * get_page_size()) as LPVOID, 1 as SIZE_T) == 0 {
+            let errorcode = GetLastError();
+            return Err(MemoryLockError::new(format!(
+                "VirtualLock: 0x{errorcode:x}"
+            )));
         }
     }
     Ok(())
@@ -28,4 +103,21 @@ pub fn memset(ptr: *mut u8, value: i32, size: usize) {
     unsafe {
         libc::memset(ptr as *mut c_void, value, size);
     }
+}
+
+fn get_page_size() -> usize {
+    *PAGE_SIZE.get_or_init(|| {
+        let mut sys_info = SYSTEM_INFO::default();
+        unsafe {
+            GetNativeSystemInfo(&mut sys_info);
+        }
+        sys_info.dwPageSize as usize
+    })
+}
+
+fn get_page_indices(ptr: *const u8, len: usize) -> std::ops::Range<usize> {
+    let page_size = get_page_size();
+    let first_page = ptr as usize / page_size;
+    let page_count = (len + page_size - 1) / page_size;
+    first_page..(first_page + page_count)
 }


### PR DESCRIPTION
Hi,

the current CryptoVec implementation on Windows unlocks memory pages too early if the backing stores of multiple CryptoVecs are located in the same page.

This is because [VirtualLock](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtuallock)/[Unlock](https://learn.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualunlock) do not implement reference-counting on the OS side:

> This function is not like the GlobalLock or LocalLock function in that it does not increment a lock count and translate a handle into a pointer. There is no lock count for virtual pages, so multiple calls to the VirtualUnlock function are never required to unlock a region of pages.

This PR adds userspace lock counting, so only once the last CryptoVec has released it's memory from a Page, the Page is unlocked.