### PR TITLE
Add crate features to enable insecure ciphers and algos

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -18,6 +18,8 @@ async-trait = ["dep:async-trait"]
 legacy-ed25519-pkcs8-parser = ["yasna"]
 # Danger: 3DES cipher is insecure.
 des = ["dep:des"]
+# Danger: DSA algorithm is insecure.
+dsa = ["ssh-key/dsa"]
 
 [dependencies]
 aes-gcm = "0.10"


### PR DESCRIPTION
Adds a crate feature to optionally enable support for insecure ciphers and algos such as RSA keys shorter than 2048 bits and DSA keys in dependency `ssh-keys`.