### PR TITLE
Optimize examples/client_open_direct_tcpip.rs

### DIFF
--- a/russh/examples/client_open_direct_tcpip.rs
+++ b/russh/examples/client_open_direct_tcpip.rs
@@ -167,7 +167,7 @@ impl Session {
                             break;
                         }
                         ChannelMsg::WindowAdjusted { new_size:_ }=> {
-                            todo!()
+                            // Ignore this message type
                         }
                         _ => {todo!()}
                     }


### PR DESCRIPTION
I think ChannelMsg::WindowAdjusted doesn't required processing by user. 