### PR TITLE
Remove unused dependencies

### DIFF
--- a/pageant/Cargo.toml
+++ b/pageant/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/warp-tech/russh"
 version = "0.0.2"
 rust-version = "1.75"
 
-[dependencies]
+[target.'cfg(windows)'.dependencies]
 futures.workspace = true
 thiserror.workspace = true
 rand.workspace = true
@@ -17,8 +17,6 @@ log.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt"] }
 bytes.workspace = true
 delegate.workspace = true
-
-[target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Memory",

--- a/russh-util/Cargo.toml
+++ b/russh-util/Cargo.toml
@@ -10,14 +10,10 @@ license = "Apache-2.0"
 repository = "https://github.com/warp-tech/russh"
 
 [dependencies]
-chrono = "0.4.38"
 tokio = { workspace = true, features = ["sync", "macros"] }
 
-[dev-dependencies]
-futures-executor = "0.3.13"
-static_assertions = "1.1.0"
-
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+chrono = "0.4.38"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.43"
 

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -93,7 +93,6 @@ tokio = { workspace = true, features = [
   "time",
   "net",
 ] }
-tokio-stream.workspace = true
 home.workspace = true
 
 [target.'cfg(windows)'.dependencies]
@@ -122,6 +121,7 @@ tempfile = "3.14.0"
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 russh-sftp = "2.0.5"
 tokio.workspace = true
+tokio-stream.workspace = true
 
 [[example]]
 name = "sftp_server"


### PR DESCRIPTION
I ran cargo-udeps on this workspace (on a Linux machine) and looked at the results.

- pageant is an empty crate on non-Windows, so all of its dependencies are Windows-only
- russh uses tokio-stream only in a doc-test. For this, dev-dependencies suffices. I do not see why this is "not wasm32", but it already was this way before, so I leave it there.
- russh-util does not seem to use futures-executor or static_assertions and apparently never did (??). These were added in commit d03df31af. In this commit, I am dropping them.
- russh-util uses chrono only on wasm