### PR TITLE
Handle unexpected EOF as expected in session closure

### DIFF
--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -652,10 +652,10 @@ impl Session {
                 Ok((0, _, _, _)) => break,
                 Ok((_, r, b, opening_cipher)) => {
                     is_reading = Some((r, b, opening_cipher));
-                },
-                // read_exact returns this error if it reads 0 bytes, this is an expected eof
-                Err(Error::IO(ref e)) if e.kind() == ErrorKind::UnexpectedEof=> break,
-                Err(e) => return Err(e.into())
+                }
+                // at this stage of session shutdown, EOF is not unexpected
+                Err(Error::IO(ref e)) if e.kind() == ErrorKind::UnexpectedEof => break,
+                Err(e) => return Err(e.into()),
             }
         }
 

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, VecDeque};
+use std::io::ErrorKind;
 use std::sync::Arc;
 
 use channels::WindowSizeRef;
@@ -647,10 +648,14 @@ impl Session {
             if let Some((stream_read, buffer, opening_cipher)) = is_reading.take() {
                 reading.set(start_reading(stream_read, buffer, opening_cipher));
             }
-            let (n, r, b, opening_cipher) = (&mut reading).await?;
-            is_reading = Some((r, b, opening_cipher));
-            if n == 0 {
-                break;
+            match (&mut reading).await {
+                Ok((0, _, _, _)) => break,
+                Ok((_, r, b, opening_cipher)) => {
+                    is_reading = Some((r, b, opening_cipher));
+                },
+                // read_exact returns this error if it reads 0 bytes, this is an expected eof
+                Err(Error::IO(ref e)) if e.kind() == ErrorKind::UnexpectedEof=> break,
+                Err(e) => return Err(e.into())
             }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/Eugeny/russh/issues/253

My session was hitting the following error after receiving a `DISCONNECT` message from the client.
```
IO(Custom { kind: UnexpectedEof, error: "early eof" })
```

On closer inspection (and thanks to the issue), I realized it was coming from the shutdown process of the session. I believe the intention here is to break when we hit eof (read 0 bytes):
https://github.com/Eugeny/russh/blob/89fed88265b402e7d505025c42f4e19ab12201f3/russh/src/server/session.rs#L650
but because of this line in the called read function
https://github.com/Eugeny/russh/blob/89fed88265b402e7d505025c42f4e19ab12201f3/russh/src/cipher/mod.rs#L254
reading 0 bytes will always be an UnexpectedEOF error. This might be good to fully propagate the error other places in the code, but here it makes sense to catch it and process it as an expected EOF.

I kept in the n == 0 check but I doubt we'd ever see that case fire since it would mean that we received an empty ssh message and I'd imagine the reason this loop exists is to make sure we're not missing any actual messages while we wait for everything to shut down.
