### PR TITLE
feat: add `ChannelReadHalf::make_reader[_ext]`, #498

### DIFF
--- a/russh/src/channels/channel_stream.rs
+++ b/russh/src/channels/channel_stream.rs
@@ -4,7 +4,7 @@ use std::task::{Context, Poll};
 
 use tokio::io::{AsyncRead, AsyncWrite};
 
-use super::io::{ChannelRx, ChannelTx};
+use super::io::{ChannelCloseOnDrop, ChannelRx, ChannelTx};
 use super::{ChannelId, ChannelMsg};
 
 /// AsyncRead/AsyncWrite wrapper for SSH Channels
@@ -13,14 +13,14 @@ where
     S: From<(ChannelId, ChannelMsg)> + 'static,
 {
     tx: ChannelTx<S>,
-    rx: ChannelRx<'static, S>,
+    rx: ChannelRx<ChannelCloseOnDrop<S>>,
 }
 
 impl<S> ChannelStream<S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
-    pub(super) fn new(tx: ChannelTx<S>, rx: ChannelRx<'static, S>) -> Self {
+    pub(super) fn new(tx: ChannelTx<S>, rx: ChannelRx<ChannelCloseOnDrop<S>>) -> Self {
         Self { tx, rx }
     }
 }

--- a/russh/src/channels/io/mod.rs
+++ b/russh/src/channels/io/mod.rs
@@ -1,4 +1,4 @@
-use super::{Channel, ChannelId, ChannelMsg};
+use super::{Channel, ChannelId, ChannelMsg, ChannelReadHalf};
 
 mod rx;
 pub use rx::ChannelRx;
@@ -9,27 +9,27 @@ pub use tx::ChannelTx;
 /// An enum with the ability to hold either an owned [`Channel`]
 /// or a `&mut` ref to it.
 #[derive(Debug)]
-pub enum ChannelAsMut<'i, S>
+pub enum ChannelRxAsMut<'i, S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
     Owned(Channel<S>),
-    RefMut(&'i mut Channel<S>),
+    RefMut(&'i mut ChannelReadHalf),
 }
 
-impl<'i, S> AsMut<Channel<S>> for ChannelAsMut<'i, S>
+impl<'i, S> AsMut<ChannelReadHalf> for ChannelRxAsMut<'i, S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
-    fn as_mut(&mut self) -> &mut Channel<S> {
+    fn as_mut(&mut self) -> &mut ChannelReadHalf {
         match self {
-            Self::Owned(channel) => channel,
+            Self::Owned(channel) => &mut channel.read_half,
             Self::RefMut(ref_mut) => ref_mut,
         }
     }
 }
 
-impl<S> From<Channel<S>> for ChannelAsMut<'static, S>
+impl<S> From<Channel<S>> for ChannelRxAsMut<'static, S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
@@ -38,11 +38,11 @@ where
     }
 }
 
-impl<'i, S> From<&'i mut Channel<S>> for ChannelAsMut<'i, S>
+impl<'i, S> From<&'i mut ChannelReadHalf> for ChannelRxAsMut<'i, S>
 where
     S: From<(ChannelId, ChannelMsg)>,
 {
-    fn from(value: &'i mut Channel<S>) -> Self {
+    fn from(value: &'i mut ChannelReadHalf) -> Self {
         Self::RefMut(value)
     }
 }

--- a/russh/src/channels/io/mod.rs
+++ b/russh/src/channels/io/mod.rs
@@ -8,6 +8,7 @@ pub use tx::ChannelTx;
 
 use crate::{Channel, ChannelId, ChannelMsg, ChannelReadHalf};
 
+#[derive(Debug)]
 pub struct ChannelCloseOnDrop<S: From<(ChannelId, ChannelMsg)>>(pub Channel<S>);
 impl<S: From<(ChannelId, ChannelMsg)>> Borrow<ChannelReadHalf> for ChannelCloseOnDrop<S> {
     fn borrow(&self) -> &ChannelReadHalf {

--- a/russh/src/channels/io/rx.rs
+++ b/russh/src/channels/io/rx.rs
@@ -5,7 +5,7 @@ use std::task::{ready, Context, Poll};
 
 use tokio::io::AsyncRead;
 
-use crate::{ChannelMsg, ChannelReadHalf};
+use super::{ChannelMsg, ChannelReadHalf};
 
 #[derive(Debug)]
 pub struct ChannelRx<R> {

--- a/russh/src/channels/io/rx.rs
+++ b/russh/src/channels/io/rx.rs
@@ -1,39 +1,33 @@
+use std::borrow::BorrowMut;
 use std::io;
 use std::pin::Pin;
 use std::task::{ready, Context, Poll};
 
 use tokio::io::AsyncRead;
 
-use super::{ChannelMsg, ChannelRxAsMut};
-use crate::ChannelId;
+use crate::{ChannelMsg, ChannelReadHalf};
 
 #[derive(Debug)]
-pub struct ChannelRx<'i, S>
-where
-    S: From<(ChannelId, ChannelMsg)>,
-{
-    channel: ChannelRxAsMut<'i, S>,
+pub struct ChannelRx<R> {
+    channel: R,
     buffer: Option<(ChannelMsg, usize)>,
 
     ext: Option<u32>,
 }
 
-impl<'i, S> ChannelRx<'i, S>
-where
-    S: From<(ChannelId, ChannelMsg)>,
-{
-    pub fn new(channel: impl Into<ChannelRxAsMut<'i, S>>, ext: Option<u32>) -> Self {
+impl<R> ChannelRx<R> {
+    pub fn new(channel: R, ext: Option<u32>) -> Self {
         Self {
-            channel: channel.into(),
+            channel,
             buffer: None,
             ext,
         }
     }
 }
 
-impl<'i, S> AsyncRead for ChannelRx<'i, S>
+impl<R> AsyncRead for ChannelRx<R>
 where
-    S: From<(ChannelId, ChannelMsg)>,
+    R: BorrowMut<ChannelReadHalf> + Unpin,
 {
     fn poll_read(
         mut self: Pin<&mut Self>,
@@ -42,7 +36,7 @@ where
     ) -> Poll<io::Result<()>> {
         let (msg, mut idx) = match self.buffer.take() {
             Some(msg) => msg,
-            None => match ready!(self.channel.as_mut().receiver.poll_recv(cx)) {
+            None => match ready!(self.channel.borrow_mut().receiver.poll_recv(cx)) {
                 Some(msg) => (msg, 0),
                 None => return Poll::Ready(Ok(())),
             },
@@ -78,7 +72,7 @@ where
                 Poll::Ready(Ok(()))
             }
             (ChannelMsg::Eof, _) => {
-                self.channel.as_mut().receiver.close();
+                self.channel.borrow_mut().receiver.close();
 
                 Poll::Ready(Ok(()))
             }
@@ -86,20 +80,6 @@ where
                 cx.waker().wake_by_ref();
                 Poll::Pending
             }
-        }
-    }
-}
-
-impl<'i, S> Drop for ChannelRx<'i, S>
-where
-    S: From<(ChannelId, ChannelMsg)>,
-{
-    fn drop(&mut self) {
-        if let ChannelRxAsMut::Owned(ref mut channel) = &mut self.channel {
-            let _ = channel
-                .write_half
-                .sender
-                .try_send((channel.write_half.id, ChannelMsg::Close).into());
         }
     }
 }

--- a/russh/src/channels/mod.rs
+++ b/russh/src/channels/mod.rs
@@ -165,7 +165,7 @@ impl ChannelReadHalf {
     /// Make a reader for the [`Channel`] to receive [`ChannelMsg::Data`] or [`ChannelMsg::ExtendedData`]
     /// depending on the `ext` parameter, through the `AsyncRead` trait.
     pub fn make_reader_ext(&mut self, ext: Option<u32>) -> impl AsyncRead + '_ {
-        io::ChannelRx::<crate::client::Msg>::new(self, ext)
+        io::ChannelRx::new(self, ext)
     }
 }
 
@@ -590,7 +590,7 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
                 self.write_half.max_packet_size,
                 None,
             ),
-            io::ChannelRx::new(self, None),
+            io::ChannelRx::new(io::ChannelCloseOnDrop(self), None),
         )
     }
 


### PR DESCRIPTION
Changes so `ChannelReadHalf` provides the `make_reader[_ext]` methods, instead of needing the whole `Channel`.

Internally replaces usages of the `ChannelAsMut<'i, S>` enum with the trait `BorrowMut<ChannelReadHalf>`. This eliminates the extraneous `'i` lifetime and `S: From<(ChannelId, ChannelMsg)>` type parameters on `ChannelRx`. To preserve the close-on-drop behavior of `ChannelRx { channel: ChannelAsMut::Owned }`, introduces `struct ChannelCloseOnDrop(Channel)`.

Also implements `Debug` for `ChannelReadHalf` and `ChannelWriteHalf`.

Related: #482, #498, #499