### PR TITLE
Can send debug messages

### DIFF
--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -752,6 +752,33 @@ impl Session {
         self.common.disconnect(reason, description, language_tag)
     }
 
+    /// Sends a debug message to the client.
+    ///
+    /// Debug messages are intended for debugging purposes and may be
+    /// optionally displayed by the client, depending on the
+    /// `always_display` flag and client configuration.
+    ///
+    /// # Parameters
+    ///
+    /// - `always_display`: If `true`, the client is encouraged to
+    ///   display the message regardless of user preferences.
+    /// - `message`: The debug message to be sent.
+    /// - `language_tag`: The language tag of the message.
+    ///
+    /// # Notes
+    ///
+    /// This message is informational and does not affect the SSH session
+    /// state. Most clients (e.g., OpenSSH) will only display the message
+    /// if verbose mode is enabled.
+    pub fn debug(
+        &mut self,
+        always_display: bool,
+        message: &str,
+        language_tag: &str,
+    ) -> Result<(), Error> {
+        self.common.debug(always_display, message, language_tag)
+    }
+
     /// Send a "success" reply to a /global/ request (requests without
     /// a channel number, such as TCP/IP forwarding or
     /// cancelling). Always call this function if the request was

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -189,6 +189,29 @@ impl<C> CommonSession<C> {
         Ok(())
     }
 
+    /// Send a debug message.
+    pub fn debug(
+        &mut self,
+        always_display: bool,
+        message: &str,
+        language_tag: &str,
+    ) -> Result<(), crate::Error> {
+        let debug = |buf: &mut CryptoVec| {
+            push_packet!(buf, {
+                msg::DEBUG.encode(buf)?;
+                (always_display as u8).encode(buf)?;
+                message.encode(buf)?;
+                language_tag.encode(buf)?;
+            });
+            Ok(())
+        };
+        return if let Some(ref mut enc) = self.encrypted {
+            debug(&mut enc.write)
+        } else {
+            debug(&mut self.packet_writer.buffer().buffer)
+        };
+    }
+
     /// Send a single byte message onto the channel.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn byte(&mut self, channel: ChannelId, msg: u8) -> Result<(), crate::Error> {


### PR DESCRIPTION
Thank you for russh 😻

I needed to send _debug_ messages. I implemented the same way disconnect is implemented as they both are session global messages.

Looking at the test suites, I did not find any appropriate place to add a test for that.

One can observe the debug messages sent by a server, for instance, by activating the `-v` option of ssh client.