### PR TITLE
Fail when accept returns an Error

### DIFF
--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -845,8 +845,9 @@ pub trait Server {
                                     }
                                 });
                             }
-
-                            _ => break,
+                            Err(e) => {
+                                return Err(e);
+                            }
                         }
                     },
 
@@ -855,8 +856,6 @@ pub trait Server {
                     }
                 }
             }
-
-            Ok(())
         }
     }
 


### PR DESCRIPTION
For instance, if the service can not accept any new connection, instead of silently terminating, it will return the underlying error:
```
Os { code: 24, kind: Uncategorized, message: "Too many open files" }
```