### PR TITLE
Fix: Dead loop when client receives messages

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -14,6 +14,7 @@
 //
 use std::cell::RefCell;
 use std::convert::TryInto;
+use std::io::Error as IoError;
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -239,6 +240,12 @@ impl Session {
                                     self.common.buffer = loop {
                                         match self.receiver.recv().await {
                                             Some(Msg::Signed { data }) => break data,
+                                            None => {
+                                                return Err(crate::Error::IO(IoError::other(
+                                                    "Failed to receive message",
+                                                ))
+                                                .into());
+                                            }
                                             _ => {}
                                         }
                                     };

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -190,7 +190,7 @@ impl Session {
                                         Some(Msg::AuthInfoResponse { responses }) => {
                                             break responses
                                         }
-                                        None => return Err(crate::Error::Disconnect.into()),
+                                        None => return Err(crate::Error::RecvError.into()),
                                         _ => {}
                                     }
                                 };
@@ -240,7 +240,7 @@ impl Session {
                                     self.common.buffer = loop {
                                         match self.receiver.recv().await {
                                             Some(Msg::Signed { data }) => break data,
-                                            None => return Err(crate::Error::Disconnect.into()),
+                                            None => return Err(crate::Error::RecvError.into()),
                                             _ => {}
                                         }
                                     };

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -14,7 +14,6 @@
 //
 use std::cell::RefCell;
 use std::convert::TryInto;
-use std::io::Error as IoError;
 use std::ops::Deref;
 use std::str::FromStr;
 
@@ -191,6 +190,7 @@ impl Session {
                                         Some(Msg::AuthInfoResponse { responses }) => {
                                             break responses
                                         }
+                                        None => return Err(crate::Error::Disconnect.into()),
                                         _ => {}
                                     }
                                 };
@@ -240,12 +240,7 @@ impl Session {
                                     self.common.buffer = loop {
                                         match self.receiver.recv().await {
                                             Some(Msg::Signed { data }) => break data,
-                                            None => {
-                                                return Err(crate::Error::IO(IoError::other(
-                                                    "Failed to receive message",
-                                                ))
-                                                .into());
-                                            }
+                                            None => return Err(crate::Error::Disconnect.into()),
                                             _ => {}
                                         }
                                     };

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -366,6 +366,7 @@ impl<H: Handler> Handle<H> {
                         prompts,
                     });
                 }
+                None => return Err(crate::Error::RecvError),
                 _ => {}
             }
         }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -316,6 +316,11 @@ pub enum Error {
 
     #[error("Invalid config: {0}")]
     InvalidConfig(String),
+
+    /// This error occurs when the channel is closed and there are no remaining messages in the channel buffer.
+    /// This is common in SSH-Agent, for example when the Agent client directly rejects an authorization request.
+    #[error("Unable to receive more messages from the channel")]
+    RecvError,
 }
 
 pub(crate) fn strict_kex_violation(message_type: u8, sequence_number: usize) -> crate::Error {


### PR DESCRIPTION
```rust
use russh::Error;
use russh::client::{Config, Handler, connect};
use russh::keys::PublicKey;
use russh::keys::agent::client::AgentClient;
use std::sync::Arc;
use std::time::Duration;
use tokio::time::sleep;

#[tokio::main]
async fn main() {
    test().await;
    sleep(Duration::from_secs(100)).await;
}

async fn test() {
    let client = Client {};
    let config = Arc::new(Config::default());
    let mut session = connect(config, ("127.0.0.1", 22), client).await.unwrap();

    let path = r#"/Users/.../Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"#;
    let mut agent = AgentClient::connect_uds(path).await.unwrap();
    let mut keys = agent.request_identities().await.unwrap();
    let key = keys.remove(0);
    let rst = session
        .authenticate_publickey_with("root", key, None, &mut agent)
        .await;
    dbg!(rst.err());
}

struct Client {}

impl Handler for Client {
    type Error = Error;
    async fn check_server_key(&mut self, _: &PublicKey) -> Result<bool, Self::Error> {
        Ok(true)
    }
}
```

This is a simple example that uses the `1Password SSH Agent` for authentication. Once I reject the authorization on `1Password`, the program enters an `infinite loop`, causing the CPU usage to reach 100%.

I am not familiar with the SSH protocol; I just happened to discover this issue. Please feel free to point out any side effects if there are any!

Thanks, russh.
