### PR TITLE
added aes128-gcm@openssh.com cipher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This is a fork of [Thrussh](https://nest.pijul.com/pijul/thrussh) by Pierre-Éti
 * `forward-streamlocal` (remote UNIX socket forwarding) ✨
 * Ciphers:
   * `chacha20-poly1305@openssh.com`
+  * `aes128-gcm@openssh.com` ✨
   * `aes256-gcm@openssh.com` ✨
   * `aes256-ctr` ✨
   * `aes192-ctr` ✨

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -22,6 +22,7 @@ use std::marker::PhantomData;
 use std::num::Wrapping;
 
 use aes::{Aes128, Aes192, Aes256};
+use aes_gcm::{Aes128Gcm, Aes256Gcm};
 use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
 use delegate::delegate;
@@ -87,6 +88,8 @@ pub const AES_192_CBC: Name = Name("aes192-cbc");
 pub const AES_256_CBC: Name = Name("aes256-cbc");
 /// `aes256-ctr`
 pub const AES_256_CTR: Name = Name("aes256-ctr");
+/// `aes128-gcm@openssh.com`
+pub const AES_128_GCM: Name = Name("aes128-gcm@openssh.com");
 /// `aes256-gcm@openssh.com`
 pub const AES_256_GCM: Name = Name("aes256-gcm@openssh.com");
 /// `chacha20-poly1305@openssh.com`
@@ -100,7 +103,8 @@ static _3DES_CBC: SshBlockCipher<CbcWrapper<des::TdesEde3>> = SshBlockCipher(Pha
 static _AES_128_CTR: SshBlockCipher<Ctr128BE<Aes128>> = SshBlockCipher(PhantomData);
 static _AES_192_CTR: SshBlockCipher<Ctr128BE<Aes192>> = SshBlockCipher(PhantomData);
 static _AES_256_CTR: SshBlockCipher<Ctr128BE<Aes256>> = SshBlockCipher(PhantomData);
-static _AES_256_GCM: GcmCipher = GcmCipher {};
+static _AES_128_GCM: GcmCipher<Aes128Gcm> = GcmCipher(PhantomData);
+static _AES_256_GCM: GcmCipher<Aes256Gcm> = GcmCipher(PhantomData);
 static _AES_128_CBC: SshBlockCipher<CbcWrapper<Aes128>> = SshBlockCipher(PhantomData);
 static _AES_192_CBC: SshBlockCipher<CbcWrapper<Aes192>> = SshBlockCipher(PhantomData);
 static _AES_256_CBC: SshBlockCipher<CbcWrapper<Aes256>> = SshBlockCipher(PhantomData);
@@ -114,6 +118,7 @@ pub static ALL_CIPHERS: &[&Name] = &[
     &AES_128_CTR,
     &AES_192_CTR,
     &AES_256_CTR,
+    &AES_128_GCM,
     &AES_256_GCM,
     &AES_128_CBC,
     &AES_192_CBC,
@@ -131,6 +136,7 @@ pub(crate) static CIPHERS: Lazy<HashMap<&'static Name, &(dyn Cipher + Send + Syn
         h.insert(&AES_128_CTR, &_AES_128_CTR);
         h.insert(&AES_192_CTR, &_AES_192_CTR);
         h.insert(&AES_256_CTR, &_AES_256_CTR);
+        h.insert(&AES_128_GCM, &_AES_128_GCM);
         h.insert(&AES_256_GCM, &_AES_256_GCM);
         h.insert(&AES_128_CBC, &_AES_128_CBC);
         h.insert(&AES_192_CBC, &_AES_192_CBC);


### PR DESCRIPTION
here is demo
```rust
#[tokio::main]
async fn main() -> anyhow::Result<()> {
    env_logger::builder()
        .filter_level(log::LevelFilter::Info)
        .init();
    let addrs = ("127.0.0.1", 22);

    let config = Config {
        preferred: russh::Preferred {
            cipher: Cow::Owned(vec![russh::cipher::AES_128_GCM]),
            ..Default::default()
        },
        ..<_>::default()
    };
    let mut session = client::connect(Arc::new(config), addrs, Client).await?;

    let client_key = ssh_key::PrivateKey::read_openssh_file(Path::new("/home/root/.ssh/id_ed25519"))?;
    let auth_ok = session
        .authenticate_publickey(
            "root",
            russh::keys::PrivateKeyWithHashAlg::new(Arc::new(client_key), None),
        )
        .await?;
    if auth_ok == client::AuthResult::Success {
        info!("success");
    }

    let channel = session.channel_open_session().await?;
    channel.exec(true, "cat > /dev/null").await?;

    let (mut read_half, write_half) = channel.split();
    let data = vec![45_u8; 1073741824];
    tokio::spawn(async move {
        match write_half.data(data.as_slice()).await {
            Ok(_) => {
                info!("write finish");
            }
            Err(e) => {
                info!("write failed: {}", e);
            }
        }
        write_half.eof().await.unwrap();
    });
    loop {
        if let Some(ChannelMsg::ExitStatus { exit_status }) = read_half.wait().await {
            info!("exit status: {}", exit_status);
            break;
        }
    }

    Ok(())
}

struct Client;

impl client::Handler for Client {
    type Error = russh::Error;

    async fn check_server_key(
        &mut self,
        _server_public_key: &ssh_key::PublicKey,
    ) -> Result<bool, Self::Error> {
        Ok(true)
    }
}
```