### PR TITLE
Support sending "no-more-sessions@openssh.com" requests

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -731,6 +731,9 @@ impl Session {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
                     }
+                    Some(GlobalRequestResponse::NoMoreSessions) => {
+                        debug!("no-more-sessions@openssh.com requests success");
+                    }
                     Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
                         let result = if r.is_empty() {
                             // If a specific port was requested, the reply has no data
@@ -766,6 +769,9 @@ impl Session {
                 match self.open_global_requests.pop_front() {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
+                    }
+                    Some(GlobalRequestResponse::NoMoreSessions) => {
+                        warn!("no-more-sessions@openssh.com requests failure");
                     }
                     Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
                         let _ = return_channel.send(None);

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -200,6 +200,9 @@ pub enum Msg {
     Keepalive {
         want_reply: bool,
     },
+    NoMoreSessions {
+        want_reply: bool,
+    },
 }
 
 impl From<(ChannelId, ChannelMsg)> for Msg {
@@ -834,6 +837,14 @@ impl<H: Handler> Handle<H> {
             .await
             .map_err(|_| Error::SendError)
     }
+
+    /// Send a no-more-sessions request to the remote peer.
+    pub async fn no_more_sessions(&self, want_reply: bool) -> Result<(), Error> {
+        self.sender
+            .send(Msg::NoMoreSessions { want_reply })
+            .await
+            .map_err(|_| Error::SendError)
+    }
 }
 
 impl<H: Handler> Future for Handle<H> {
@@ -1375,6 +1386,9 @@ impl Session {
             }
             Msg::Keepalive { want_reply } => {
                 let _ = self.send_keepalive(want_reply);
+            }
+            Msg::NoMoreSessions { want_reply } => {
+                let _ = self.no_more_sessions(want_reply);
             }
             msg => {
                 // should be unreachable, since the receiver only gets

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -414,6 +414,19 @@ impl Session {
         Ok(())
     }
 
+    pub fn no_more_sessions(&mut self, want_reply: bool) -> Result<(), crate::Error> {
+        self.open_global_requests
+            .push_back(crate::session::GlobalRequestResponse::NoMoreSessions);
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                msg::GLOBAL_REQUEST.encode(&mut enc.write)?;
+                "no-more-sessions@openssh.com".encode(&mut enc.write)?;
+                (want_reply as u8).encode(&mut enc.write)?;
+            });
+        }
+        Ok(())
+    }
+
     pub fn data(&mut self, channel: ChannelId, data: CryptoVec) -> Result<(), crate::Error> {
         if let Some(ref mut enc) = self.common.encrypted {
             enc.data(channel, data, self.kex.active())

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -585,6 +585,8 @@ pub(crate) struct NewKeys {
 pub(crate) enum GlobalRequestResponse {
     /// request was for Keepalive, ignore result
     Keepalive,
+    /// request was for NoMoreSessions, disallow additional sessions
+    NoMoreSessions,
     /// request was for TcpIpForward, sends Some(port) for success or None for failure
     TcpIpForward(oneshot::Sender<Option<u32>>),
     /// request was for CancelTcpIpForward, sends true for success or false for failure


### PR DESCRIPTION
This is the default behavior when openssh client connect to openssh server. 
It improves the security as openssh described in PROTOCOL:
```
2.2. connection: disallow additional sessions extension
     "no-more-sessions@openssh.com"

Most SSH connections will only ever request a single session, but a
attacker may abuse a running ssh client to surreptitiously open
additional sessions under their control. OpenSSH provides a global
request "no-more-sessions@openssh.com" to mitigate this attack.

When an OpenSSH client expects that it will never open another session
(i.e. it has been started with connection multiplexing disabled), it
will send the following global request:

       byte            SSH_MSG_GLOBAL_REQUEST
       string          "no-more-sessions@openssh.com"
       char            want-reply

On receipt of such a message, an OpenSSH server will refuse to open
future channels of type "session" and instead immediately abort the
connection.

Note that this is not a general defence against compromised clients
(that is impossible), but it thwarts a simple attack.
```
here is minimal demo:
```rust
use russh::client;
use russh::client::Config;
use russh::keys::ssh_key;
use russh::ChannelMsg;

use log::info;
use std::sync::Arc;

#[tokio::main]
async fn main() -> anyhow::Result<()> {
    env_logger::builder()
        .filter_level(log::LevelFilter::Debug)
        .init();
    let addrs = ("192.168.1.1", 22);

    let config = Config::default();
    let mut session = client::connect(Arc::new(config), addrs, Client).await?;

    let auth_ok = session.authenticate_password("root", "password").await?;
    if auth_ok != client::AuthResult::Success {
        anyhow::bail!("login failed")
    }

    let mut channel = session.channel_open_session().await?;
    channel.exec(true, "id").await?;
    session.no_more_sessions(true).await?;
    loop {
        if let Some(ChannelMsg::ExitStatus { exit_status }) = channel.wait().await {
            info!("exit status: {}", exit_status);
            break;
        }
    }
   // open session again
    let _channel = session.channel_open_session().await?;

    Ok(())
}

struct Client;

// #[async_trait]
impl client::Handler for Client {
    type Error = russh::Error;

    async fn check_server_key(
        &mut self,
        _server_public_key: &ssh_key::PublicKey,
    ) -> Result<bool, Self::Error> {
        Ok(true)
    }
}
```
Since the demo open session twice after send '"no-more-sessions@openssh.com" request. the connection is aborted by openssh server.
here is debug log:
```
...
[2025-06-12T05:44:45Z DEBUG russh::client] disconnected: ReceivedDisconnect(RemoteDisconnectInfo { reason_code: ProtocolError, message: "Possible attack: attempt to open a session after additional sessions disabled", lang_tag: "" })
...
```