### PR TITLE
Use `ring` implementation for ChaCha20Poly1305 cipher

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,5 +105,5 @@ jobs:
 
     - name: Check with minimal dependency versions
       run: |
-        rustup toolchain add 1.77.0
-        cargo +1.77.0 minimal-versions check --all-features --no-dev-deps
+        rustup toolchain add 1.75.0
+        cargo +1.75.0 minimal-versions check --all-features --no-dev-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,5 +105,5 @@ jobs:
 
     - name: Check with minimal dependency versions
       run: |
-        rustup toolchain add 1.75.0
-        cargo +1.75.0 minimal-versions check --all-features --no-dev-deps
+        rustup toolchain add 1.77.0
+        cargo +1.77.0 minimal-versions check --all-features --no-dev-deps

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -25,7 +25,6 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
-aws-lc-rs = { version = "1.13.1" }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
@@ -63,6 +62,7 @@ pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
+ring = "0.17"
 rsa.workspace = true
 russh-cryptovec = { version = "0.52.0", path = "../cryptovec", features = [
   "ssh-encoding",

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -10,7 +10,7 @@ name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
 version = "0.52.1"
-rust-version = "1.77"
+rust-version = "1.75"
 
 [features]
 default = ["flate2"]

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -10,7 +10,7 @@ name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
 version = "0.52.1"
-rust-version = "1.75"
+rust-version = "1.77"
 
 [features]
 default = ["flate2"]
@@ -25,7 +25,7 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
-aws-lc-rs = "1.13.1"
+aws-lc-rs = { version = "1.13.1" }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -25,12 +25,12 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
+aws-lc-rs = "1.13.1"
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
 bytes.workspace = true
 cbc = { version = "0.1" }
-chacha20 = "0.9"
 ctr = "0.9"
 curve25519-dalek = "4.1.3"
 data-encoding = "2.3"
@@ -61,7 +61,6 @@ pbkdf2 = "0.12"
 pkcs1 = "0.7"
 pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
-poly1305 = "0.8"
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
 rsa.workspace = true

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -15,7 +15,7 @@
 
 // http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 
-use aws_lc_rs::aead::chacha20_poly1305_openssh;
+use ring::aead::chacha20_poly1305_openssh;
 
 use super::super::Error;
 use crate::mac::MacAlgorithm;
@@ -27,7 +27,6 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         chacha20_poly1305_openssh::KEY_LEN
     }
 
-    #[allow(clippy::indexing_slicing)] // length checked
     fn make_opening_key(
         &self,
         k: &[u8],
@@ -41,7 +40,6 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         )))
     }
 
-    #[allow(clippy::indexing_slicing)] // length checked
     fn make_sealing_key(
         &self,
         k: &[u8],
@@ -77,7 +75,6 @@ impl super::OpeningKey for OpeningKey {
         chacha20_poly1305_openssh::TAG_LEN
     }
 
-    #[allow(clippy::indexing_slicing)] // lengths checked
     fn open<'a>(
         &mut self,
         sequence_number: u32,

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -36,7 +36,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
     ) -> Box<dyn super::OpeningKey + Send> {
         Box::new(OpeningKey(chacha20_poly1305_openssh::OpeningKey::new(
             #[allow(clippy::unwrap_used)]
-            k.first_chunk().unwrap(),
+            k.try_into().unwrap(),
         )))
     }
 
@@ -49,7 +49,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
     ) -> Box<dyn super::SealingKey + Send> {
         Box::new(SealingKey(chacha20_poly1305_openssh::SealingKey::new(
             #[allow(clippy::unwrap_used)]
-            k.first_chunk().unwrap(),
+            k.try_into().unwrap(),
         )))
     }
 }
@@ -67,7 +67,7 @@ impl super::OpeningKey for OpeningKey {
         self.0.decrypt_packet_length(
             sequence_number,
             #[allow(clippy::unwrap_used)]
-            *encrypted_packet_length.first_chunk().unwrap(),
+            encrypted_packet_length.try_into().unwrap(),
         )
     }
 
@@ -86,7 +86,7 @@ impl super::OpeningKey for OpeningKey {
                 sequence_number,
                 ciphertext_in_plaintext_out,
                 #[allow(clippy::unwrap_used)]
-                tag.first_chunk().unwrap(),
+                tag.try_into().unwrap(),
             )
             .map_err(|_| Error::DecryptionError)
     }
@@ -132,7 +132,7 @@ impl super::SealingKey for SealingKey {
             sequence_number,
             plaintext_in_ciphertext_out,
             #[allow(clippy::unwrap_used)]
-            tag.first_chunk_mut().unwrap(),
+            tag.try_into().unwrap(),
         );
     }
 }

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -36,6 +36,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::OpeningKey + Send> {
         Box::new(OpeningKey(chacha20_poly1305_openssh::OpeningKey::new(
+            #[allow(clippy::unwrap_used)]
             k.first_chunk().unwrap(),
         )))
     }
@@ -49,6 +50,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::SealingKey + Send> {
         Box::new(SealingKey(chacha20_poly1305_openssh::SealingKey::new(
+            #[allow(clippy::unwrap_used)]
             k.first_chunk().unwrap(),
         )))
     }
@@ -66,6 +68,7 @@ impl super::OpeningKey for OpeningKey {
     ) -> [u8; 4] {
         self.0.decrypt_packet_length(
             sequence_number,
+            #[allow(clippy::unwrap_used)]
             *encrypted_packet_length.first_chunk().unwrap(),
         )
     }
@@ -85,6 +88,7 @@ impl super::OpeningKey for OpeningKey {
             .open_in_place(
                 sequence_number,
                 ciphertext_in_plaintext_out,
+                #[allow(clippy::unwrap_used)]
                 tag.first_chunk().unwrap(),
             )
             .map_err(|_| Error::DecryptionError)
@@ -130,6 +134,7 @@ impl super::SealingKey for SealingKey {
         self.0.seal_in_place(
             sequence_number,
             plaintext_in_ciphertext_out,
+            #[allow(clippy::unwrap_used)]
             tag.first_chunk_mut().unwrap(),
         );
     }

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -124,11 +124,6 @@ impl<C: AeadCore + AeadInPlace> super::OpeningKey for OpeningKey<C> {
         #[allow(clippy::indexing_slicing)] // length checked
         packet_length.clone_from_slice(&ciphertext_in_plaintext_out[..super::PACKET_LENGTH_LEN]);
 
-        let mut buffer = vec![0; ciphertext_in_plaintext_out.len() - super::PACKET_LENGTH_LEN];
-
-        #[allow(clippy::indexing_slicing)] // length checked
-        buffer.copy_from_slice(&ciphertext_in_plaintext_out[super::PACKET_LENGTH_LEN..]);
-
         let mut tag_buf = GenericArray::<u8, <C as AeadCore>::TagSize>::default();
         tag_buf.clone_from_slice(tag);
 


### PR DESCRIPTION
Followup to #532.

By switching from the RustCrypto implementation of ChaCha20Poly1305-OpenSSH to `ring`, my port forwarding benchmarks resulted in a substantial performance gain of an order of magnitude.

As a disclaimer, I have not tested this against an OpenSSH implementation to make sure that it's fully compatible.

---

With `russh = "0.52.1"`:

![image](https://github.com/user-attachments/assets/c0d29130-ef0a-477c-b1ac-7e570d0e58cb)
= 7s 933ms

---

With this PR:

![image](https://github.com/user-attachments/assets/8e1d8da5-d255-4192-9aa0-ece0e3af2785)
= 662 ms