### PR TITLE
Use `ring` implementation for AES-GCM ciphers

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -22,7 +22,6 @@ des = ["dep:des"]
 dsa = ["ssh-key/dsa"]
 
 [dependencies]
-aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
 bitflags = "2.0"
@@ -64,6 +63,7 @@ pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
 poly1305 = "0.8"
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
+ring = "0.17"
 rsa.workspace = true
 russh-cryptovec = { version = "0.52.0", path = "../cryptovec", features = [
   "ssh-encoding",

--- a/russh/src/cipher/block.rs
+++ b/russh/src/cipher/block.rs
@@ -122,9 +122,10 @@ impl<C: BlockStreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for Open
     fn open<'a>(
         &mut self,
         sequence_number: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
+        let ciphertext_len = ciphertext_and_tag.len() - self.tag_len();
+        let (ciphertext_in_plaintext_out, tag) = ciphertext_and_tag.split_at_mut(ciphertext_len);
         if self.mac.is_etm() {
             if !self
                 .mac

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -117,9 +117,10 @@ impl super::OpeningKey for OpeningKey {
     fn open<'a>(
         &mut self,
         sequence_number: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
+        let ciphertext_len = ciphertext_and_tag.len() - self.tag_len();
+        let (ciphertext_in_plaintext_out, tag) = ciphertext_and_tag.split_at_mut(ciphertext_len);
         let nonce = make_counter(sequence_number);
         let expected_tag = compute_poly1305(&nonce, &self.k2, ciphertext_in_plaintext_out);
 

--- a/russh/src/cipher/clear.rs
+++ b/russh/src/cipher/clear.rs
@@ -63,12 +63,10 @@ impl super::OpeningKey for Key {
     fn open<'a>(
         &mut self,
         _seqn: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_plaintext: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
-        debug_assert_eq!(tag.len(), 0); // self.tag_len());
         #[allow(clippy::indexing_slicing)] // length known
-        Ok(&ciphertext_in_plaintext_out[4..])
+        Ok(&ciphertext_and_plaintext[4..])
     }
 }
 

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -17,26 +17,24 @@
 
 use std::convert::TryInto;
 
-use aes_gcm::{AeadCore, AeadInPlace, KeyInit, KeySizeUser};
-use digest::typenum::Unsigned;
-use generic_array::GenericArray;
 use rand::RngCore;
-use std::marker::PhantomData;
+use ring::aead::{
+    Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,
+    SealingKey as AeadSealingKey, UnboundKey, NONCE_LEN,
+};
 
 use super::super::Error;
 use crate::mac::MacAlgorithm;
 
-pub struct GcmCipher<C: AeadCore + AeadInPlace + KeyInit + KeySizeUser>(pub PhantomData<C>);
+pub struct GcmCipher(pub(crate) &'static Algorithm);
 
-impl<C: AeadCore + AeadInPlace + KeyInit + KeySizeUser + Send + 'static> super::Cipher
-    for GcmCipher<C>
-{
+impl super::Cipher for GcmCipher {
     fn key_len(&self) -> usize {
-        C::key_size()
+        self.0.key_len()
     }
 
     fn nonce_len(&self) -> usize {
-        GenericArray::<u8, <C as AeadCore>::NonceSize>::default().len()
+        self.0.nonce_len()
     }
 
     fn make_opening_key(
@@ -46,14 +44,11 @@ impl<C: AeadCore + AeadInPlace + KeyInit + KeySizeUser + Send + 'static> super::
         _: &[u8],
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::OpeningKey + Send> {
-        let mut key = GenericArray::<u8, <C as KeySizeUser>::KeySize>::default();
-        key.clone_from_slice(k);
-        let mut nonce = GenericArray::<u8, <C as AeadCore>::NonceSize>::default();
-        nonce.clone_from_slice(n);
-        Box::new(OpeningKey {
-            nonce,
-            cipher: C::new(&key),
-        })
+        #[allow(clippy::unwrap_used)]
+        Box::new(OpeningKey(AeadOpeningKey::new(
+            UnboundKey::new(self.0, k).unwrap(),
+            Nonce(n.try_into().unwrap()),
+        )))
     }
 
     fn make_sealing_key(
@@ -63,41 +58,34 @@ impl<C: AeadCore + AeadInPlace + KeyInit + KeySizeUser + Send + 'static> super::
         _: &[u8],
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::SealingKey + Send> {
-        let mut key = GenericArray::<u8, <C as KeySizeUser>::KeySize>::default();
-        key.clone_from_slice(k);
-        let mut nonce = GenericArray::<u8, <C as AeadCore>::NonceSize>::default();
-        nonce.clone_from_slice(n);
-        Box::new(SealingKey {
-            nonce,
-            cipher: C::new(&key),
-        })
+        #[allow(clippy::unwrap_used)]
+        Box::new(SealingKey(AeadSealingKey::new(
+            UnboundKey::new(self.0, k).unwrap(),
+            Nonce(n.try_into().unwrap()),
+        )))
     }
 }
 
-pub struct OpeningKey<C: AeadCore + AeadInPlace> {
-    nonce: GenericArray<u8, <C as AeadCore>::NonceSize>,
-    cipher: C,
-}
+pub struct OpeningKey<N: NonceSequence>(AeadOpeningKey<N>);
 
-pub struct SealingKey<C: AeadCore + AeadInPlace> {
-    nonce: GenericArray<u8, <C as AeadCore>::NonceSize>,
-    cipher: C,
-}
+pub struct SealingKey<N: NonceSequence>(AeadSealingKey<N>);
 
-fn inc_nonce<C>(nonce: &mut GenericArray<u8, <C as AeadCore>::NonceSize>)
-where
-    C: AeadCore,
-{
-    let mut carry = 1;
-    #[allow(clippy::indexing_slicing)] // length checked
-    for i in (0..nonce.len()).rev() {
-        let n = nonce[i] as u16 + carry;
-        nonce[i] = n as u8;
-        carry = n >> 8;
+struct Nonce([u8; NONCE_LEN]);
+
+impl NonceSequence for Nonce {
+    fn advance(&mut self) -> Result<ring::aead::Nonce, ring::error::Unspecified> {
+        let mut carry = 1;
+        #[allow(clippy::indexing_slicing)] // length checked
+        for i in (0..NONCE_LEN).rev() {
+            let n = self.0[i] as u16 + carry;
+            self.0[i] = n as u8;
+            carry = n >> 8;
+        }
+        Ok(AeadNonce::assume_unique_for_key(self.0))
     }
 }
 
-impl<C: AeadCore + AeadInPlace> super::OpeningKey for OpeningKey<C> {
+impl<N: NonceSequence> super::OpeningKey for OpeningKey<N> {
     fn decrypt_packet_length(
         &self,
         _sequence_number: u32,
@@ -109,47 +97,37 @@ impl<C: AeadCore + AeadInPlace> super::OpeningKey for OpeningKey<C> {
     }
 
     fn tag_len(&self) -> usize {
-        <C as AeadCore>::TagSize::to_usize()
+        self.0.algorithm().tag_len()
     }
 
     fn open<'a>(
         &mut self,
         _sequence_number: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
         // Packet length is sent unencrypted
         let mut packet_length = [0; super::PACKET_LENGTH_LEN];
 
         #[allow(clippy::indexing_slicing)] // length checked
-        packet_length.clone_from_slice(&ciphertext_in_plaintext_out[..super::PACKET_LENGTH_LEN]);
+        packet_length.clone_from_slice(&ciphertext_and_tag[..super::PACKET_LENGTH_LEN]);
 
-        let mut buffer = vec![0; ciphertext_in_plaintext_out.len() - super::PACKET_LENGTH_LEN];
-
-        #[allow(clippy::indexing_slicing)] // length checked
-        buffer.copy_from_slice(&ciphertext_in_plaintext_out[super::PACKET_LENGTH_LEN..]);
-
-        let mut tag_buf = GenericArray::<u8, <C as AeadCore>::TagSize>::default();
-        tag_buf.clone_from_slice(tag);
-
-        #[allow(clippy::indexing_slicing)]
-        self.cipher
-            .decrypt_in_place_detached(
-                &self.nonce,
-                &packet_length,
-                &mut ciphertext_in_plaintext_out[super::PACKET_LENGTH_LEN..],
-                &tag_buf,
+        self.0
+            .open_in_place(
+                Aad::from(&packet_length),
+                #[allow(clippy::indexing_slicing)] // length checked
+                &mut ciphertext_and_tag[super::PACKET_LENGTH_LEN..],
             )
             .map_err(|_| Error::DecryptionError)?;
 
-        inc_nonce::<C>(&mut self.nonce);
-
-        #[allow(clippy::indexing_slicing)]
-        Ok(&ciphertext_in_plaintext_out[super::PACKET_LENGTH_LEN..])
+        #[allow(clippy::indexing_slicing)] // length checked
+        Ok(
+            &ciphertext_and_tag
+                [super::PACKET_LENGTH_LEN..ciphertext_and_tag.len() - self.tag_len()],
+        )
     }
 }
 
-impl<C: AeadCore + AeadInPlace> super::SealingKey for SealingKey<C> {
+impl<N: NonceSequence> super::SealingKey for SealingKey<N> {
     fn padding_length(&self, payload: &[u8]) -> usize {
         let block_size = 16;
         let extra_len = super::PACKET_LENGTH_LEN + super::PADDING_LENGTH_LEN;
@@ -170,7 +148,7 @@ impl<C: AeadCore + AeadInPlace> super::SealingKey for SealingKey<C> {
     }
 
     fn tag_len(&self) -> usize {
-        <C as AeadCore>::TagSize::to_usize()
+        self.0.algorithm().tag_len()
     }
 
     fn seal(
@@ -184,17 +162,16 @@ impl<C: AeadCore + AeadInPlace> super::SealingKey for SealingKey<C> {
         #[allow(clippy::indexing_slicing)] // length checked
         packet_length.clone_from_slice(&plaintext_in_ciphertext_out[..super::PACKET_LENGTH_LEN]);
 
-        #[allow(clippy::indexing_slicing, clippy::unwrap_used)]
+        #[allow(clippy::unwrap_used)]
         let tag_out = self
-            .cipher
-            .encrypt_in_place_detached(
-                &self.nonce,
-                &packet_length,
+            .0
+            .seal_in_place_separate_tag(
+                Aad::from(&packet_length),
+                #[allow(clippy::indexing_slicing)]
                 &mut plaintext_in_ciphertext_out[super::PACKET_LENGTH_LEN..],
             )
             .unwrap();
 
-        inc_nonce::<C>(&mut self.nonce);
-        tag.clone_from_slice(&tag_out)
+        tag.clone_from_slice(tag_out.as_ref())
     }
 }


### PR DESCRIPTION
Followup to #532. This implementation changes the signature for the `OpeningKey::open` method to not split the tag from the cipher prematurely.

As a disclaimer, I have not tested this against an OpenSSH implementation to make sure that it's fully compatible.

---

AES_256_GCM with `russh = "0.52.1"`:

![image](https://github.com/user-attachments/assets/5e42aee7-f6c5-4886-8b7a-062caf4e4fe6)
= 6s 248ms

---

AES_256_GCM with this PR:

![image](https://github.com/user-attachments/assets/2ddd9e37-8869-4a13-8382-6129c9d1ead7)
= 552ms