### PR TITLE
Use `aws-lc-rs`/`ring` implementation for AEAD ciphers

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -571,6 +571,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "wyhaya",
+      "name": "wyhaya",
+      "avatar_url": "https://avatars.githubusercontent.com/u/23690145?v=4",
+      "profile": "https://github.com/wyhaya",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,5 +105,5 @@ jobs:
 
     - name: Check with minimal dependency versions
       run: |
-        rustup toolchain add 1.77.0
-        cargo +1.77.0 minimal-versions check --all-features --no-dev-deps
+        rustup toolchain add 1.75.0
+        cargo +1.75.0 minimal-versions check --all-features --no-dev-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,5 +105,5 @@ jobs:
 
     - name: Check with minimal dependency versions
       run: |
-        rustup toolchain add 1.75.0
-        cargo +1.75.0 minimal-versions check --all-features --no-dev-deps
+        rustup toolchain add 1.77.0
+        cargo +1.77.0 minimal-versions check --all-features --no-dev-deps

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,6 +54,10 @@ jobs:
       run: |
         cargo install --force --locked bindgen-cli
 
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y gcc-multilib
+
     - name: Build (all features enabled)
       run: cargo +1.81.0 build --verbose --target wasm32-wasip1 -p russh
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: install nasm
+      run: |
+        choco install nasm
+        echo "C:\Program Files\NASM" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
     - name: Build (no features enabled)
       run: cargo build --verbose
 
@@ -44,6 +49,10 @@ jobs:
       run: |
         rustup toolchain add 1.81.0
         rustup target add --toolchain 1.81.0 wasm32-wasip1
+
+    - name: Install bindgen-cli
+      run: |
+        cargo install --force --locked bindgen-cli
 
     - name: Build (all features enabled)
       run: cargo +1.81.0 build --verbose --target wasm32-wasip1 -p russh

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,14 +50,6 @@ jobs:
         rustup toolchain add 1.81.0
         rustup target add --toolchain 1.81.0 wasm32-wasip1
 
-    - name: Install bindgen-cli
-      run: |
-        cargo install --force --locked bindgen-cli
-
-    - name: Install dependencies
-      run: |
-        sudo apt-get install -y gcc-multilib
-
     - name: Build (all features enabled)
       run: cargo +1.81.0 build --verbose --target wasm32-wasip1 -p russh
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,8 +50,8 @@ jobs:
         rustup toolchain add 1.81.0
         rustup target add --toolchain 1.81.0 wasm32-wasip1
 
-    - name: Build (all features enabled)
-      run: cargo +1.81.0 build --verbose --target wasm32-wasip1 -p russh
+    - name: Build (WASM-compatible features)
+      run: cargo +1.81.0 build --verbose --target wasm32-wasip1 --no-default-features --features flate2,ring -p russh
 
   Formatting:
     runs-on: ubuntu-24.04

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Russh
 
 [![Rust](https://github.com/warp-tech/russh/actions/workflows/rust.yml/badge.svg)](https://github.com/warp-tech/russh/actions/workflows/rust.yml)  <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
-[![All Contributors](https://img.shields.io/badge/all_contributors-63-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-64-orange.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 Low-level Tokio SSH2 client and server implementation.
@@ -203,6 +203,9 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/lgmugnier"><img src="https://avatars.githubusercontent.com/u/10800317?v=4?s=100" width="100px;" alt="lgmugnier"/><br /><sub><b>lgmugnier</b></sub></a><br /><a href="https://github.com/Eugeny/russh/commits?author=lgmugnier" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/MingweiSamuel"><img src="https://avatars.githubusercontent.com/u/6778341?v=4?s=100" width="100px;" alt="Mingwei Samuel"/><br /><sub><b>Mingwei Samuel</b></sub></a><br /><a href="https://github.com/Eugeny/russh/commits?author=MingweiSamuel" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://twitter.com/pascalgrange"><img src="https://avatars.githubusercontent.com/u/378506?v=4?s=100" width="100px;" alt="Pascal Grange"/><br /><sub><b>Pascal Grange</b></sub></a><br /><a href="https://github.com/Eugeny/russh/commits?author=pgrange" title="Code">💻</a></td>
+    </tr>
+    <tr>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/wyhaya"><img src="https://avatars.githubusercontent.com/u/23690145?v=4?s=100" width="100px;" alt="wyhaya"/><br /><sub><b>wyhaya</b></sub></a><br /><a href="https://github.com/Eugeny/russh/commits?author=wyhaya" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -22,7 +22,6 @@ des = ["dep:des"]
 dsa = ["ssh-key/dsa"]
 
 [dependencies]
-aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
 bitflags = "2.0"

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -25,7 +25,6 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
-aws-lc-rs = { version = "1.13.1" }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
@@ -63,6 +62,7 @@ pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
+ring = "0.17"
 rsa.workspace = true
 russh-cryptovec = { version = "0.52.0", path = "../cryptovec", features = [
   "ssh-encoding",

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -13,18 +13,21 @@ version = "0.52.1"
 rust-version = "1.75"
 
 [features]
-default = ["flate2"]
+default = ["flate2", "aws-lc-rs"]
+aws-lc-rs = ["dep:aws-lc-rs"]
 async-trait = ["dep:async-trait"]
 legacy-ed25519-pkcs8-parser = ["yasna"]
 # Danger: 3DES cipher is insecure.
 des = ["dep:des"]
 # Danger: DSA algorithm is insecure.
 dsa = ["ssh-key/dsa"]
+ring = ["dep:ring"]
 _bench = ["dep:criterion"]
 
 [dependencies]
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
+aws-lc-rs = { version = "1.13.1", optional = true }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
@@ -62,6 +65,7 @@ pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
+ring = { version = "0.17.14", optional = true }
 rsa.workspace = true
 russh-cryptovec = { version = "0.52.0", path = "../cryptovec", features = [
   "ssh-encoding",
@@ -94,10 +98,6 @@ tokio = { workspace = true, features = [
   "net",
 ] }
 home.workspace = true
-aws-lc-rs = "1.13.1"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-ring = "0.17.14"
 
 [target.'cfg(windows)'.dependencies]
 pageant = { version = "0.0.3", path = "../pageant" }

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -10,7 +10,7 @@ name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
 version = "0.52.1"
-rust-version = "1.77"
+rust-version = "1.75"
 
 [features]
 default = ["flate2"]

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -10,7 +10,7 @@ name = "russh"
 readme = "../README.md"
 repository = "https://github.com/warp-tech/russh"
 version = "0.52.1"
-rust-version = "1.75"
+rust-version = "1.77"
 
 [features]
 default = ["flate2"]
@@ -25,7 +25,7 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
-aws-lc-rs = "1.13.1"
+aws-lc-rs = { version = "1.13.1" }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -85,7 +85,6 @@ yasna = { version = "0.5.0", features = [
 zeroize = "1.7"
 base64ct = "~1.6" # can be removed in 2024 edition
 criterion = { version = "0.3", optional = true, features = ["html_reports"] }
-aws-lc-rs = "1.13.1"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { workspace = true, features = [
@@ -95,6 +94,10 @@ tokio = { workspace = true, features = [
   "net",
 ] }
 home.workspace = true
+aws-lc-rs = "1.13.1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+ring = "0.17.14"
 
 [target.'cfg(windows)'.dependencies]
 pageant = { version = "0.0.3", path = "../pageant" }

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -25,12 +25,12 @@ dsa = ["ssh-key/dsa"]
 aes-gcm = "0.10"
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
+aws-lc-rs = "1.13.1"
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
 bytes.workspace = true
 cbc = { version = "0.1" }
-chacha20 = "0.9"
 ctr = "0.9"
 curve25519-dalek = "4.1.3"
 data-encoding = "2.3"
@@ -61,7 +61,6 @@ pbkdf2 = "0.12"
 pkcs1 = "0.7"
 pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
-poly1305 = "0.8"
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
 rsa.workspace = true

--- a/russh/src/cipher/block.rs
+++ b/russh/src/cipher/block.rs
@@ -122,9 +122,10 @@ impl<C: BlockStreamCipher + KeySizeUser + IvSizeUser> super::OpeningKey for Open
     fn open<'a>(
         &mut self,
         sequence_number: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
+        let ciphertext_len = ciphertext_and_tag.len() - self.tag_len();
+        let (ciphertext_in_plaintext_out, tag) = ciphertext_and_tag.split_at_mut(ciphertext_len);
         if self.mac.is_etm() {
             if !self
                 .mac

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -15,7 +15,7 @@
 
 // http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 
-use aws_lc_rs::aead::chacha20_poly1305_openssh;
+use ring::aead::chacha20_poly1305_openssh;
 
 use super::super::Error;
 use crate::mac::MacAlgorithm;
@@ -27,7 +27,6 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         chacha20_poly1305_openssh::KEY_LEN
     }
 
-    #[allow(clippy::indexing_slicing)] // length checked
     fn make_opening_key(
         &self,
         k: &[u8],
@@ -41,7 +40,6 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         )))
     }
 
-    #[allow(clippy::indexing_slicing)] // length checked
     fn make_sealing_key(
         &self,
         k: &[u8],
@@ -77,7 +75,6 @@ impl super::OpeningKey for OpeningKey {
         chacha20_poly1305_openssh::TAG_LEN
     }
 
-    #[allow(clippy::indexing_slicing)] // lengths checked
     fn open<'a>(
         &mut self,
         sequence_number: u32,

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -36,7 +36,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
     ) -> Box<dyn super::OpeningKey + Send> {
         Box::new(OpeningKey(chacha20_poly1305_openssh::OpeningKey::new(
             #[allow(clippy::unwrap_used)]
-            k.first_chunk().unwrap(),
+            k.try_into().unwrap(),
         )))
     }
 
@@ -49,7 +49,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
     ) -> Box<dyn super::SealingKey + Send> {
         Box::new(SealingKey(chacha20_poly1305_openssh::SealingKey::new(
             #[allow(clippy::unwrap_used)]
-            k.first_chunk().unwrap(),
+            k.try_into().unwrap(),
         )))
     }
 }
@@ -67,7 +67,7 @@ impl super::OpeningKey for OpeningKey {
         self.0.decrypt_packet_length(
             sequence_number,
             #[allow(clippy::unwrap_used)]
-            *encrypted_packet_length.first_chunk().unwrap(),
+            encrypted_packet_length.try_into().unwrap(),
         )
     }
 
@@ -86,7 +86,7 @@ impl super::OpeningKey for OpeningKey {
                 sequence_number,
                 ciphertext_in_plaintext_out,
                 #[allow(clippy::unwrap_used)]
-                tag.first_chunk().unwrap(),
+                tag.try_into().unwrap(),
             )
             .map_err(|_| Error::DecryptionError)
     }
@@ -132,7 +132,7 @@ impl super::SealingKey for SealingKey {
             sequence_number,
             plaintext_in_ciphertext_out,
             #[allow(clippy::unwrap_used)]
-            tag.first_chunk_mut().unwrap(),
+            tag.try_into().unwrap(),
         );
     }
 }

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -15,9 +15,9 @@
 
 // http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::aead::chacha20_poly1305_openssh;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
 use ring::aead::chacha20_poly1305_openssh;
 
 use super::super::Error;

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -36,6 +36,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::OpeningKey + Send> {
         Box::new(OpeningKey(chacha20_poly1305_openssh::OpeningKey::new(
+            #[allow(clippy::unwrap_used)]
             k.first_chunk().unwrap(),
         )))
     }
@@ -49,6 +50,7 @@ impl super::Cipher for SshChacha20Poly1305Cipher {
         _: &dyn MacAlgorithm,
     ) -> Box<dyn super::SealingKey + Send> {
         Box::new(SealingKey(chacha20_poly1305_openssh::SealingKey::new(
+            #[allow(clippy::unwrap_used)]
             k.first_chunk().unwrap(),
         )))
     }
@@ -66,6 +68,7 @@ impl super::OpeningKey for OpeningKey {
     ) -> [u8; 4] {
         self.0.decrypt_packet_length(
             sequence_number,
+            #[allow(clippy::unwrap_used)]
             *encrypted_packet_length.first_chunk().unwrap(),
         )
     }
@@ -85,6 +88,7 @@ impl super::OpeningKey for OpeningKey {
             .open_in_place(
                 sequence_number,
                 ciphertext_in_plaintext_out,
+                #[allow(clippy::unwrap_used)]
                 tag.first_chunk().unwrap(),
             )
             .map_err(|_| Error::DecryptionError)
@@ -130,6 +134,7 @@ impl super::SealingKey for SealingKey {
         self.0.seal_in_place(
             sequence_number,
             plaintext_in_ciphertext_out,
+            #[allow(clippy::unwrap_used)]
             tag.first_chunk_mut().unwrap(),
         );
     }

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -15,7 +15,10 @@
 
 // http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/usr.bin/ssh/PROTOCOL.chacha20poly1305?annotate=HEAD
 
+#[cfg(not(target_arch = "wasm32"))]
 use aws_lc_rs::aead::chacha20_poly1305_openssh;
+#[cfg(target_arch = "wasm32")]
+use ring::aead::chacha20_poly1305_openssh;
 
 use super::super::Error;
 use crate::mac::MacAlgorithm;

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -78,15 +78,17 @@ impl super::OpeningKey for OpeningKey {
     fn open<'a>(
         &mut self,
         sequence_number: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
+        let ciphertext_len = ciphertext_and_tag.len() - self.tag_len();
+        let (ciphertext_in_plaintext_out, tag) = ciphertext_and_tag.split_at_mut(ciphertext_len);
+
         self.0
             .open_in_place(
                 sequence_number,
                 ciphertext_in_plaintext_out,
                 #[allow(clippy::unwrap_used)]
-                tag.try_into().unwrap(),
+                tag.as_ref().try_into().unwrap(),
             )
             .map_err(|_| Error::DecryptionError)
     }

--- a/russh/src/cipher/clear.rs
+++ b/russh/src/cipher/clear.rs
@@ -63,12 +63,10 @@ impl super::OpeningKey for Key {
     fn open<'a>(
         &mut self,
         _seqn: u32,
-        ciphertext_in_plaintext_out: &'a mut [u8],
-        tag: &[u8],
+        ciphertext_and_tag: &'a mut [u8],
     ) -> Result<&'a [u8], Error> {
-        debug_assert_eq!(tag.len(), 0); // self.tag_len());
         #[allow(clippy::indexing_slicing)] // length known
-        Ok(&ciphertext_in_plaintext_out[4..])
+        Ok(&ciphertext_and_tag[4..])
     }
 }
 

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -17,11 +17,23 @@
 
 use std::convert::TryInto;
 
-use aws_lc_rs::aead::{
-    Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,
-    SealingKey as AeadSealingKey, UnboundKey, NONCE_LEN,
+#[cfg(not(target_arch = "wasm32"))]
+use aws_lc_rs::{
+    aead::{
+        Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,
+        SealingKey as AeadSealingKey, UnboundKey, NONCE_LEN,
+    },
+    error::Unspecified,
 };
 use rand::RngCore;
+#[cfg(target_arch = "wasm32")]
+use ring::{
+    aead::{
+        Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,
+        SealingKey as AeadSealingKey, UnboundKey, NONCE_LEN,
+    },
+    error::Unspecified,
+};
 
 use super::super::Error;
 use crate::mac::MacAlgorithm;
@@ -73,7 +85,7 @@ pub struct SealingKey<N: NonceSequence>(AeadSealingKey<N>);
 struct Nonce([u8; NONCE_LEN]);
 
 impl NonceSequence for Nonce {
-    fn advance(&mut self) -> Result<aws_lc_rs::aead::Nonce, aws_lc_rs::error::Unspecified> {
+    fn advance(&mut self) -> Result<AeadNonce, Unspecified> {
         let mut previous_nonce = [0u8; NONCE_LEN];
         #[allow(clippy::indexing_slicing)] // length checked
         previous_nonce.clone_from_slice(&self.0[..]);

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -17,7 +17,7 @@
 
 use std::convert::TryInto;
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::{
     aead::{
         Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,
@@ -26,7 +26,7 @@ use aws_lc_rs::{
     error::Unspecified,
 };
 use rand::RngCore;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
 use ring::{
     aead::{
         Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -74,6 +74,9 @@ struct Nonce([u8; NONCE_LEN]);
 
 impl NonceSequence for Nonce {
     fn advance(&mut self) -> Result<ring::aead::Nonce, ring::error::Unspecified> {
+        let mut previous_nonce = [0u8; NONCE_LEN];
+        #[allow(clippy::indexing_slicing)] // length checked
+        previous_nonce.clone_from_slice(&self.0[..]);
         let mut carry = 1;
         #[allow(clippy::indexing_slicing)] // length checked
         for i in (0..NONCE_LEN).rev() {
@@ -81,7 +84,7 @@ impl NonceSequence for Nonce {
             self.0[i] = n as u8;
             carry = n >> 8;
         }
-        Ok(AeadNonce::assume_unique_for_key(self.0))
+        Ok(AeadNonce::assume_unique_for_key(previous_nonce))
     }
 }
 

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -111,7 +111,8 @@ impl<N: NonceSequence> super::OpeningKey for OpeningKey<N> {
         #[allow(clippy::indexing_slicing)] // length checked
         packet_length.clone_from_slice(&ciphertext_and_tag[..super::PACKET_LENGTH_LEN]);
 
-        self.0
+        let buf = self
+            .0
             .open_in_place(
                 Aad::from(&packet_length),
                 #[allow(clippy::indexing_slicing)] // length checked
@@ -119,11 +120,7 @@ impl<N: NonceSequence> super::OpeningKey for OpeningKey<N> {
             )
             .map_err(|_| Error::DecryptionError)?;
 
-        #[allow(clippy::indexing_slicing)] // length checked
-        Ok(
-            &ciphertext_and_tag
-                [super::PACKET_LENGTH_LEN..ciphertext_and_tag.len() - self.tag_len()],
-        )
+        Ok(buf)
     }
 }
 
@@ -172,6 +169,6 @@ impl<N: NonceSequence> super::SealingKey for SealingKey<N> {
             )
             .unwrap();
 
-        tag.clone_from_slice(tag_out.as_ref())
+        tag.clone_from_slice(tag_out.as_ref());
     }
 }

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -124,11 +124,6 @@ impl<C: AeadCore + AeadInPlace> super::OpeningKey for OpeningKey<C> {
         #[allow(clippy::indexing_slicing)] // length checked
         packet_length.clone_from_slice(&ciphertext_in_plaintext_out[..super::PACKET_LENGTH_LEN]);
 
-        let mut buffer = vec![0; ciphertext_in_plaintext_out.len() - super::PACKET_LENGTH_LEN];
-
-        #[allow(clippy::indexing_slicing)] // length checked
-        buffer.copy_from_slice(&ciphertext_in_plaintext_out[super::PACKET_LENGTH_LEN..]);
-
         let mut tag_buf = GenericArray::<u8, <C as AeadCore>::TagSize>::default();
         tag_buf.clone_from_slice(tag);
 

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -22,12 +22,15 @@ use std::marker::PhantomData;
 use std::num::Wrapping;
 
 use aes::{Aes128, Aes192, Aes256};
+#[cfg(not(target_arch = "wasm32"))]
 use aws_lc_rs::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
 use delegate::delegate;
 use log::trace;
 use once_cell::sync::Lazy;
+#[cfg(target_arch = "wasm32")]
+use ring::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use ssh_encoding::Encode;
 use tokio::io::{AsyncRead, AsyncReadExt};
 

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -22,14 +22,14 @@ use std::marker::PhantomData;
 use std::num::Wrapping;
 
 use aes::{Aes128, Aes192, Aes256};
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
 use delegate::delegate;
 use log::trace;
 use once_cell::sync::Lazy;
-#[cfg(target_arch = "wasm32")]
+#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
 use ring::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use ssh_encoding::Encode;
 use tokio::io::{AsyncRead, AsyncReadExt};


### PR DESCRIPTION
Closes #532.

By switching the ChaCha20Poly1305, AES-GCM-128 and AES-GCM-256 ciphers from the RustCrypto implementation to `ring`'s, [my port forwarding benchmarks](https://github.com/EpicEric/sandhole/blob/main/tests/https_single_stream_download.rs) resulted in a substantial performance gain of an order of magnitude on my machine.

||With current `main` | With this PR |
|-|-|-|
|ChaCha20Poly1305|8s 18ms|662 ms|
|AES-GCM-128|6s 280ms|557ms|
|AES-GCM-256|6s 396ms|552ms|

But results seem to vary depending on your hardware, where we see much smaller or no gains. On a different machine with limited memory and less CPU power (and a different benchmark):

||With current `main` | With this PR |
|-|-|-|
|ChaCha20Poly1305|660ms|654ms|
|AES-GCM-256|803ms|615ms|

This implementation also changes the signature for the `OpeningKey::open` method to not split the tag from the cipher prematurely.

I have tested ChaCha20Poly1305 and AES-GCM-256 against the current release of russh and OpenSSH, but not AES-GCM-128, although I expect it to work the same.