### PR TITLE
feat: make `Config` `Clone`

### DIFF
--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -28,7 +28,7 @@ pub enum Error {
 mod proxy;
 pub use proxy::*;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub user: String,
     pub host_name: String,
@@ -301,5 +301,11 @@ Host test_host
             config.user_known_hosts_file.as_deref()
         );
         assert!(!config.strict_host_key_checking);
+    }
+
+    #[test]
+    fn is_clone() {
+        let config: Config = Config::default("some_host");
+        let _ = config.clone();
     }
 }


### PR DESCRIPTION
`russh_config::Config` would be useful to clone around since it may need to be inspected at different times during the lifecycle of an ssh connection / session.