### PR TITLE
fix: allow `Stream` to connect to multiple addresses

### DIFF
--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -5,7 +5,6 @@
     clippy::panic
 )]
 use std::io::Read;
-use std::net::ToSocketAddrs;
 use std::path::Path;
 
 use globset::Glob;
@@ -19,8 +18,6 @@ pub enum Error {
     HostNotFound,
     #[error("No home directory")]
     NoHome,
-    #[error("Cannot resolve the address")]
-    NotResolvable,
     #[error("{}", 0)]
     Io(#[from] std::io::Error),
 }
@@ -80,11 +77,9 @@ impl Config {
                 .await
                 .map_err(Into::into)
         } else {
-            let address = (self.host_name.as_str(), self.port)
-                .to_socket_addrs()?
-                .next()
-                .ok_or(Error::NotResolvable)?;
-            Stream::tcp_connect(&address).await.map_err(Into::into)
+            Stream::tcp_connect((self.host_name.as_str(), self.port))
+                .await
+                .map_err(Into::into)
         }
     }
 }

--- a/russh-config/src/proxy.rs
+++ b/russh-config/src/proxy.rs
@@ -1,4 +1,3 @@
-use std::net::SocketAddr;
 use std::pin::Pin;
 use std::process::Stdio;
 
@@ -6,6 +5,7 @@ use futures::ready;
 use futures::task::*;
 use tokio::io::ReadBuf;
 use tokio::net::TcpStream;
+use tokio::net::ToSocketAddrs;
 use tokio::process::Command;
 
 /// A type to implement either a TCP socket, or proxying through an external command.
@@ -18,8 +18,8 @@ pub enum Stream {
 
 impl Stream {
     /// Connect a direct TCP stream (as opposed to a proxied one).
-    pub async fn tcp_connect(addr: &SocketAddr) -> Result<Stream, std::io::Error> {
-        Ok(Stream::Tcp(tokio::net::TcpStream::connect(addr).await?))
+    pub async fn tcp_connect(addrs: impl ToSocketAddrs) -> Result<Stream, std::io::Error> {
+        Ok(Stream::Tcp(tokio::net::TcpStream::connect(addrs).await?))
     }
     /// Connect through a proxy command.
     pub async fn proxy_command(cmd: &str, args: &[&str]) -> Result<Stream, std::io::Error> {


### PR DESCRIPTION
Previously, when using `config.stream()`, it would resolve the host, port pair and pick the first address returned. But Tokio has built-in support to resolve multiple addresses and connect to each one until one succeeds. So this PR lifts the previous restriction.

The main consquence is that the `Error::NotResolvable` is gone since it will be reported as an `Io` error by Tokio instead.