### PR TITLE
Add TCP_NODELAY option for client

### DIFF
--- a/russh/examples/client_open_direct_tcpip.rs
+++ b/russh/examples/client_open_direct_tcpip.rs
@@ -10,6 +10,7 @@ use anyhow::Result;
 use clap::Parser;
 use key::PrivateKeyWithHashAlg;
 use log::info;
+use russh::client::Config;
 use russh::keys::*;
 use russh::*;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -81,7 +82,12 @@ impl Session {
         addrs: A,
     ) -> Result<Self> {
         let key_pair = load_secret_key(key_path, None)?;
-        let config = client::Config::default();
+
+        let config = Config {
+            nodelay: true,
+            ..Default::default()
+        };
+
         // load ssh certificate
         let mut openssh_cert = None;
         if openssh_cert_path.is_some() {


### PR DESCRIPTION
This PR adds a `nodelay` option to the russh client implementation, similar to a previous PR #435 that did this for the server implementation.

While using Warpgate as a jumphost between my DB server and my local system, I noticed a large performance impact when executing SQL queries sequentially due to high latency. Warpgate was about twice as slow in my test workload, compared to SSH directly to the server. After testing with `russh` directly, I found that by enabling this option, I could get on par performance with normal SSH.

After the next release of russh happens, I'd like to contribute some changes to Warpgate itself as well, to allow enabling `nodelay` for it's SSH server- and client-side via the config.