### PR TITLE
Fix channels being closed prematurely

### DIFF
--- a/russh/benches/ciphers.rs
+++ b/russh/benches/ciphers.rs
@@ -1,4 +1,7 @@
-use criterion::{criterion_group, criterion_main};
-use russh::cipher::benchmark::bench;
-criterion_group!(benches, bench);
-criterion_main!(benches);
+#[cfg(feature = "_bench")]
+criterion::criterion_group!(benches, russh::cipher::benchmark::bench);
+#[cfg(feature = "_bench")]
+criterion::criterion_main!(benches);
+
+#[cfg(not(feature = "_bench"))]
+fn main() {}

--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use log::info;
 use rand_core::OsRng;
 use russh::keys::{Certificate, *};
 use russh::server::{Msg, Server as _, Session};

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -887,12 +887,20 @@ impl Session {
 
     /// Close a channel.
     pub fn close(&mut self, channel: ChannelId) -> Result<(), Error> {
-        self.common.byte(channel, msg::CHANNEL_CLOSE)
+        if let Some(ref mut enc) = self.common.encrypted {
+            enc.close(channel)
+        } else {
+            unreachable!()
+        }
     }
 
     /// Send EOF to a channel
     pub fn eof(&mut self, channel: ChannelId) -> Result<(), Error> {
-        self.common.byte(channel, msg::CHANNEL_EOF)
+        if let Some(ref mut enc) = self.common.encrypted {
+            enc.eof(channel)
+        } else {
+            unreachable!()
+        }
     }
 
     /// Send data to a channel. On session channels, `extended` can be

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -212,15 +212,6 @@ impl<C> CommonSession<C> {
         };
     }
 
-    /// Send a single byte message onto the channel.
-    #[cfg(not(target_arch = "wasm32"))]
-    pub fn byte(&mut self, channel: ChannelId, msg: u8) -> Result<(), crate::Error> {
-        if let Some(ref mut enc) = self.encrypted {
-            enc.byte(channel, msg)?
-        }
-        Ok(())
-    }
-
     pub(crate) fn reset_seqn(&mut self) {
         self.packet_writer.reset_seqn();
     }


### PR DESCRIPTION
Closes #553.

Previously, the server session would immediately set the EOF or close message on the encrypted channel's session, which could result in a race condition between it and the last data message, sporadically causing the latter to be dropped.

This change makes the behavior match that of the client session, setting a flag for flushing in case there's pending data.