### PR TITLE
Add a hook-trigger to the handler.

### DIFF
--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -76,6 +76,7 @@ impl server::Server for Server {
 
 impl server::Handler for Server {
     type Error = russh::Error;
+    type Data = ();
 
     async fn channel_open_session(
         &mut self,

--- a/russh/examples/echoserver_certificates.rs
+++ b/russh/examples/echoserver_certificates.rs
@@ -109,6 +109,7 @@ impl server::Server for Server {
 
 impl server::Handler for Server {
     type Error = russh::Error;
+    type Data = ();
 
     async fn channel_open_session(
         &mut self,

--- a/russh/examples/ratatui_app.rs
+++ b/russh/examples/ratatui_app.rs
@@ -143,6 +143,7 @@ impl Server for AppServer {
 
 impl Handler for AppServer {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn channel_open_session(
         &mut self,

--- a/russh/examples/ratatui_shared_app.rs
+++ b/russh/examples/ratatui_shared_app.rs
@@ -145,6 +145,7 @@ impl Server for AppServer {
 
 impl Handler for AppServer {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn channel_open_session(
         &mut self,

--- a/russh/examples/sftp_server.rs
+++ b/russh/examples/sftp_server.rs
@@ -41,6 +41,7 @@ impl SshSession {
 
 impl russh::server::Handler for SshSession {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_password(&mut self, user: &str, password: &str) -> Result<Auth, Self::Error> {
         info!("credentials: {user}, {password}");

--- a/russh/examples/test.rs
+++ b/russh/examples/test.rs
@@ -47,6 +47,7 @@ impl server::Server for Server {
 
 impl server::Handler for Server {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn channel_open_session(
         &mut self,

--- a/russh/src/client/test.rs
+++ b/russh/src/client/test.rs
@@ -33,6 +33,7 @@ mod tests {
 
     impl ServerHandler for TestServer {
         type Error = Error;
+        type Data = ();
 
         async fn channel_open_session(
             &mut self,

--- a/russh/src/client/test.rs
+++ b/russh/src/client/test.rs
@@ -34,6 +34,7 @@ mod tests {
 
     impl ServerHandler for TestServer {
         type Error = Error;
+        type Data = ();
 
         async fn channel_open_session(
             &mut self,

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -225,6 +225,7 @@ mod tests {
 
         impl Handler for Probe {
             type Error = Error;
+            type Data = ();
 
             async fn auth_publickey_offered(
                 &mut self,
@@ -426,6 +427,7 @@ mod tests {
 
         impl Handler for Probe {
             type Error = Error;
+            type Data = ();
 
             async fn auth_publickey_offered(
                 &mut self,
@@ -526,6 +528,7 @@ mod tests {
 
     impl Handler for ChannelCallbackProbe {
         type Error = Error;
+        type Data = ();
 
         async fn exec_request(
             &mut self,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -810,12 +810,12 @@ pub trait Handler: Sized {
     /// use russh::server::Handler;
     ///
     /// struct App{
-    ///     foo: String
+    ///     foo: String,
     ///     recv: Receiver<String>,
     ///     trigger: Receiver<String>,
     /// }
     ///
-    /// impl App for Handler {
+    /// impl Handler for App {
     ///     type Error = russh::Error;
     ///     type Data = String;
     ///     async fn trigger(&mut self) -> Result<Self::Data, Self::Error> {

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -834,7 +834,7 @@ pub trait Handler: Sized {
     /// ```
     ///
     fn trigger(&mut self) -> impl Future<Output = Result<Self::Data, Self::Error>> + Send {
-        return std::future::pending();
+        std::future::pending()
     }
 
     /// Called after [`trigger`], See [`trigger`] for more.

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -842,6 +842,7 @@ pub trait Handler: Sized {
     fn process(
         &mut self,
         data: Self::Data,
+        session: &mut Session,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async { Ok(()) }
     }

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -210,6 +210,7 @@ impl Auth {
 #[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 pub trait Handler: Sized {
     type Error: From<crate::Error> + Send;
+    type Data: Send;
 
     /// Check authentication using the "none" method. Russh makes
     /// sure rejection happens in time `config.auth_rejection_time`,
@@ -792,6 +793,57 @@ pub trait Handler: Sized {
 
             Ok(Some(best_group.clone()))
         }
+    }
+
+    /// Called when the handler needs to be updated.
+    /// ['trigger'] should be used with ['process']
+    ///
+    /// # Cancel safety
+    ///
+    /// The safety of this method depends entirely on how you implement it;
+    /// it provides no inherent security guarantees.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::sync::mpsc::Receiver;
+    /// use russh::server::Handler;
+    ///
+    /// struct App{
+    ///     foo: String
+    ///     recv: Receiver<String>,
+    ///     trigger: Receiver<String>,
+    /// }
+    ///
+    /// impl App for Handler {
+    ///     type Error = russh::Error;
+    ///     type Data = String;
+    ///     async fn trigger(&mut self) -> Result<Self::Data, Self::Error> {
+    ///         match self.trigger.recv().await {
+    ///             Some(d) => Ok(d),
+    ///             None => std::future::pending().await,
+    ///         }
+    ///     }
+    ///
+    ///     async fn process(&mut self, s: Self::Data) -> Result<(), Self::Error> {
+    ///         let s = self.recv.recv().await.unwrap();
+    ///         self.foo = s;
+    ///         Ok(())
+    ///     }
+    /// }
+    /// ```
+    ///
+    fn trigger(&mut self) -> impl Future<Output = Result<Self::Data, Self::Error>> + Send {
+        return std::future::pending();
+    }
+
+    /// Called after [`trigger`], See [`trigger`] for more.
+    #[allow(unused_variables)]
+    fn process(
+        &mut self,
+        data: Self::Data,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
     }
 }
 

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -807,7 +807,7 @@ pub trait Handler: Sized {
     ///
     /// ```
     /// use tokio::sync::mpsc::Receiver;
-    /// use russh::server::Handler;
+    /// use russh::server::{Handler, Session};
     ///
     /// struct App{
     ///     foo: String,
@@ -825,7 +825,7 @@ pub trait Handler: Sized {
     ///         }
     ///     }
     ///
-    ///     async fn process(&mut self, s: Self::Data) -> Result<(), Self::Error> {
+    ///     async fn process(&mut self, s: Self::Data, session: &mut Session) -> Result<(), Self::Error> {
     ///         let s = self.recv.recv().await.unwrap();
     ///         self.foo = s;
     ///         Ok(())

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -214,6 +214,7 @@ impl Auth {
 #[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 pub trait Handler: Sized {
     type Error: From<crate::Error> + Send;
+    type Data: Send;
 
     /// Check authentication using the "none" method.
     ///
@@ -848,6 +849,58 @@ pub trait Handler: Sized {
 
             Ok(Some(best_group.clone()))
         }
+    }
+
+    /// Called when the handler needs to be updated.
+    /// ['trigger'] should be used with ['process']
+    ///
+    /// # Cancel safety
+    ///
+    /// The safety of this method depends entirely on how you implement it;
+    /// it provides no inherent security guarantees.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tokio::sync::mpsc::Receiver;
+    /// use russh::server::{Handler, Session};
+    ///
+    /// struct App{
+    ///     foo: String,
+    ///     recv: Receiver<String>,
+    ///     trigger: Receiver<String>,
+    /// }
+    ///
+    /// impl Handler for App {
+    ///     type Error = russh::Error;
+    ///     type Data = String;
+    ///     async fn trigger(&mut self) -> Result<Self::Data, Self::Error> {
+    ///         match self.trigger.recv().await {
+    ///             Some(d) => Ok(d),
+    ///             None => std::future::pending().await,
+    ///         }
+    ///     }
+    ///
+    ///     async fn process(&mut self, s: Self::Data, session: &mut Session) -> Result<(), Self::Error> {
+    ///         let s = self.recv.recv().await.unwrap();
+    ///         self.foo = s;
+    ///         Ok(())
+    ///     }
+    /// }
+    /// ```
+    ///
+    fn trigger(&mut self) -> impl Future<Output = Result<Self::Data, Self::Error>> + Send {
+        std::future::pending()
+    }
+
+    /// Called after [`trigger`], See [`trigger`] for more.
+    #[allow(unused_variables)]
+    fn process(
+        &mut self,
+        data: Self::Data,
+        session: &mut Session,
+    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
+        async { Ok(()) }
     }
 }
 

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -550,7 +550,7 @@ impl Session {
                 t = handler.trigger() => {
                     debug!("handler trigger is invoked");
                     match t {
-                        Ok(d) => handler.process(d).await?,
+                        Ok(d) => handler.process(d,&mut self).await?,
                         Err(e) => return Err(e)
                     }
                 }

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -547,6 +547,13 @@ impl Session {
                     }
                     reading.set(start_reading(stream_read, buffer, opening_cipher));
                 }
+                t = handler.trigger() => {
+                    debug!("handler trigger is invoked");
+                    match t {
+                        Ok(d) => handler.process(d).await?,
+                        Err(e) => return Err(e)
+                    }
+                }
                 () = &mut keepalive_timer => {
                     self.common.alive_timeouts = self.common.alive_timeouts.saturating_add(1);
                     if self.common.config.keepalive_max != 0 && self.common.alive_timeouts > self.common.config.keepalive_max {

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -1343,6 +1343,7 @@ mod tests {
 
     impl crate::server::Handler for TestHandler {
         type Error = crate::Error;
+        type Data = ();
     }
 
     fn authenticated_session() -> Session {

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -746,6 +746,13 @@ impl Session {
                     }
                     reading.set(start_reading(stream_read, buffer, opening_cipher));
                 }
+                t = handler.trigger() => {
+                    debug!("handler trigger is invoked");
+                    match t {
+                        Ok(d) => handler.process(d,&mut self).await?,
+                        Err(e) => return Err(e)
+                    }
+                }
                 () = &mut keepalive_timer => {
                     self.common.alive_timeouts = self.common.alive_timeouts.saturating_add(1);
                     if self.common.config.keepalive_max != 0 && self.common.alive_timeouts > self.common.config.keepalive_max {
@@ -1515,6 +1522,7 @@ mod tests {
 
     impl crate::server::Handler for TestHandler {
         type Error = crate::Error;
+        type Data = ();
     }
 
     fn authenticated_session() -> Session {

--- a/russh/src/tests.rs
+++ b/russh/src/tests.rs
@@ -526,6 +526,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -1331,6 +1332,7 @@ mod future_certificate {
 
             impl server::Handler for CertHandler {
                 type Error = crate::Error;
+                type Data = ();
 
                 async fn auth_publickey_offered(
                     &mut self,

--- a/russh/src/tests.rs
+++ b/russh/src/tests.rs
@@ -1128,6 +1128,7 @@ pub(crate) mod raw_no_crypto {
 
     impl server::Handler for MalformedInputServer {
         type Error = Error;
+        type Data = ();
 
         async fn auth_none(&mut self, _user: &str) -> Result<server::Auth, Self::Error> {
             self.record("auth_none");

--- a/russh/src/tests.rs
+++ b/russh/src/tests.rs
@@ -109,6 +109,7 @@ mod compress {
 
     impl server::Handler for Server {
         type Error = super::Error;
+        type Data = ();
 
         async fn channel_open_session(
             &mut self,
@@ -283,6 +284,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -354,6 +356,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -438,6 +441,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -602,6 +606,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -741,6 +746,7 @@ mod server_kex_junk {
 
     impl server::Handler for Server {
         type Error = super::Error;
+        type Data = ();
     }
 }
 

--- a/russh/src/tests.rs
+++ b/russh/src/tests.rs
@@ -110,6 +110,7 @@ mod compress {
 
     impl server::Handler for Server {
         type Error = super::Error;
+        type Data = ();
 
         async fn channel_open_session(
             &mut self,
@@ -289,6 +290,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -360,6 +362,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -446,6 +449,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -532,6 +536,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -614,6 +619,7 @@ mod channels {
 
         impl server::Handler for ServerHandle {
             type Error = crate::Error;
+            type Data = ();
 
             async fn auth_publickey(
                 &mut self,
@@ -755,6 +761,7 @@ mod server_kex_junk {
 
     impl server::Handler for Server {
         type Error = super::Error;
+        type Data = ();
     }
 }
 
@@ -1206,6 +1213,7 @@ pub(crate) mod raw_no_crypto {
 
     impl server::Handler for MalformedInputServer {
         type Error = Error;
+        type Data = ();
 
         async fn auth_none(&mut self, _user: &str) -> Result<server::Auth, Self::Error> {
             self.record("auth_none");
@@ -1409,6 +1417,7 @@ mod future_certificate {
 
             impl server::Handler for CertHandler {
                 type Error = crate::Error;
+                type Data = ();
 
                 async fn auth_publickey_offered(
                     &mut self,

--- a/russh/tests/auth_state_reset.rs
+++ b/russh/tests/auth_state_reset.rs
@@ -21,6 +21,7 @@ struct RemainingMethodsUserSwitchServer;
 
 impl server::Handler for RemainingMethodsUserSwitchServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_none(&mut self, user: &str) -> Result<server::Auth, Self::Error> {
         if user == "alice" {

--- a/russh/tests/auth_state_reset.rs
+++ b/russh/tests/auth_state_reset.rs
@@ -22,6 +22,7 @@ struct RemainingMethodsUserSwitchServer;
 
 impl server::Handler for RemainingMethodsUserSwitchServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_none(&mut self, user: &str) -> Result<server::Auth, Self::Error> {
         if user == "alice" {

--- a/russh/tests/test_backpressure.rs
+++ b/russh/tests/test_backpressure.rs
@@ -114,6 +114,7 @@ impl russh::server::Server for Server {
 
 impl russh::server::Handler for Server {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_backpressure.rs
+++ b/russh/tests/test_backpressure.rs
@@ -243,6 +243,7 @@ impl russh::server::Server for HandleBackpressureServer {
 
 impl russh::server::Handler for HandleBackpressureServer {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_backpressure.rs
+++ b/russh/tests/test_backpressure.rs
@@ -174,6 +174,7 @@ impl russh::server::Server for Server {
 
 impl russh::server::Handler for Server {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_contention.rs
+++ b/russh/tests/test_contention.rs
@@ -125,6 +125,7 @@ impl russh::server::Server for Server {
 
 impl russh::server::Handler for Server {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_data_stream.rs
+++ b/russh/tests/test_data_stream.rs
@@ -183,6 +183,7 @@ impl russh::server::Server for Server {
 
 impl russh::server::Handler for Server {
     type Error = anyhow::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_kex_shared_secret.rs
+++ b/russh/tests/test_kex_shared_secret.rs
@@ -360,6 +360,7 @@ struct TestServer {}
 
 impl server::Handler for TestServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_max_channel_packet_size.rs
+++ b/russh/tests/test_max_channel_packet_size.rs
@@ -160,6 +160,7 @@ struct EchoServer {}
 
 impl server::Handler for EchoServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_mlkem_kex.rs
+++ b/russh/tests/test_mlkem_kex.rs
@@ -330,6 +330,7 @@ struct TestServer {}
 
 impl server::Handler for TestServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_rekey_strict_kex.rs
+++ b/russh/tests/test_rekey_strict_kex.rs
@@ -116,6 +116,7 @@ struct TestServer {}
 // Insecure server that accepts any public key and echos back data it receives; ONLY FOR TESTS
 impl server::Handler for TestServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,

--- a/russh/tests/test_server_cert.rs
+++ b/russh/tests/test_server_cert.rs
@@ -222,6 +222,7 @@ struct TestServer {}
 
 impl server::Handler for TestServer {
     type Error = russh::Error;
+    type Data = ();
 
     async fn auth_publickey(
         &mut self,


### PR DESCRIPTION
## Note: this is a breaking API change.
**New feather:**
    This is useful if you need to update the handler
    without relying on a mutex (or similar synchronization).

here is demo
```rust
use tokio::sync::mpsc::Receiver;
use russh::server::Handler;

struct App{
    foo: String
    recv: Receiver<String>,
    trigger: Receiver<String>,
}

impl App for Handler {
    type Error = russh::Error;
    type Data = String;
    async fn trigger(&mut self) -> Result<Self::Data, Self::Error> {
        match self.trigger.recv().await {
            Some(d) => Ok(d),
            None => std::future::pending().await,
        }
    }

    async fn process(&mut self, s: Self::Data) -> Result<(), Self::Error> {
        let s = self.recv.recv().await.unwrap();
        self.foo = s;
        Ok(())
    }
}

```