### PR TITLE
fix Tabby#10301 Still cannot login with pageant

### DIFF
--- a/pageant/Cargo.toml
+++ b/pageant/Cargo.toml
@@ -13,11 +13,12 @@ rust-version = "1.75"
 futures.workspace = true
 thiserror.workspace = true
 rand.workspace = true
+byteorder.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["io-util", "rt"] }
 bytes.workspace = true
 delegate.workspace = true
-windows = { version = "0.58", features = [
+windows = { version = "0.59", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_System_Memory",
     "Win32_Security",


### PR DESCRIPTION
two problems:
1. pageant protocol does not support streaming, so PageantStream should receive enough data for pageant, and then forward into.
2. [SECURITY_ATTRIBUTES] should have the correct nLength
3. [SetSecurityDescriptorOwner] in version 0.58 have bug, upgrade to 0.59 is ok.