### PR TITLE
Update globset in russh-config to 0.4

### DIFF
--- a/russh-config/Cargo.toml
+++ b/russh-config/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.75"
 [dependencies]
 home.workspace = true
 futures.workspace = true
-globset = "0.3"
+globset = "0.4"
 log.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "macros", "process"] }


### PR DESCRIPTION
`globset` in `russh-config` was set to a very old version (0.3), from 2018. This transitively also pulls in a very old version of `regex` (0.2), which required a build script. Fixing this removes a build script from the transitive dependency set, making `russh-config` easier to build in non-Cargo environments as well.

Tests in `russh-config` pass:
```sh
♪ cd russh-config
♪ cargo test
   Compiling russh-config v0.54.0 (/code/russh/russh-config)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.52s
     Running unittests src/lib.rs (/code/russh/target/debug/deps/russh_config-24c26694da1c4719)

running 5 tests
test tests::expand_home ... ok
test tests::strip_quotes ... ok
test tests::is_clone ... ok
test tests::default_config ... ok
test tests::basic_config ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests russh_config

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
