### PR TITLE
fix: use sha256 as the default hashing algorithm when running agent tests

### DIFF
--- a/russh/src/keys/mod.rs
+++ b/russh/src/keys/mod.rs
@@ -860,7 +860,10 @@ Cog3JMeTrb3LiPHgN6gU2P30MRp6L1j1J/MtlOAr5rux
         client.request_identities().await?;
         let buf = russh_cryptovec::CryptoVec::from_slice(b"blabla");
         let len = buf.len();
-        let buf = client.sign_request(public, None, buf).await.unwrap();
+        let buf = client
+            .sign_request(public, Some(HashAlg::Sha256), buf)
+            .await
+            .unwrap();
         let (a, b) = buf.split_at(len);
 
         match key.public_key().key_data() {


### PR DESCRIPTION
Hello, https://github.com/Eugeny/russh/pull/449 added the possibility of specifying the hashing algorithm, but didn't add a default that work on all systems.
This sets the tests to use sha256 by default so that they run an all systems, including RedHat-based distributions.

Fixes #444