### PR TITLE
A send_ping method for measuring latency

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -744,6 +744,9 @@ impl Session {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
                     }
+                    Some(GlobalRequestResponse::Ping(return_channel)) => {
+                        let _ = return_channel.send(());
+                    }
                     Some(GlobalRequestResponse::NoMoreSessions) => {
                         debug!("no-more-sessions@openssh.com requests success");
                     }
@@ -782,6 +785,9 @@ impl Session {
                 match self.open_global_requests.pop_front() {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
+                    }
+                    Some(GlobalRequestResponse::Ping(return_channel)) => {
+                        let _ = return_channel.send(());
                     }
                     Some(GlobalRequestResponse::NoMoreSessions) => {
                         warn!("no-more-sessions@openssh.com requests failure");

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -416,6 +416,19 @@ impl Session {
         Ok(())
     }
 
+    pub fn send_ping(&mut self, reply_channel: oneshot::Sender<()>) -> Result<(), crate::Error> {
+        self.open_global_requests
+            .push_back(crate::session::GlobalRequestResponse::Ping(reply_channel));
+        if let Some(ref mut enc) = self.common.encrypted {
+            push_packet!(enc.write, {
+                msg::GLOBAL_REQUEST.encode(&mut enc.write)?;
+                "keepalive@openssh.com".encode(&mut enc.write)?;
+                (true as u8).encode(&mut enc.write)?;
+            });
+        }
+        Ok(())
+    }
+
     pub fn no_more_sessions(&mut self, want_reply: bool) -> Result<(), crate::Error> {
         self.open_global_requests
             .push_back(crate::session::GlobalRequestResponse::NoMoreSessions);

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -582,6 +582,8 @@ pub(crate) struct NewKeys {
 pub(crate) enum GlobalRequestResponse {
     /// request was for Keepalive, ignore result
     Keepalive,
+    /// request was for Keepalive but with notification of the result
+    Ping(oneshot::Sender<()>),
     /// request was for NoMoreSessions, disallow additional sessions
     NoMoreSessions,
     /// request was for TcpIpForward, sends Some(port) for success or None for failure


### PR DESCRIPTION
The already supported send_keepalive method is useful for keeping the connection alive, but when the application wants to measure the latency, we need to wait for the response before returning.

"ping" is a rather basic networking feature, but there is a reason why so many protocols have their own ping utility (arping, ndping, hping, httping, ws-ping, quicreach, etc.). Different networks just need different diagnostic tools.

My personal usecase is that I want to do a latency check - to a host that only serves SSH - through a SOCKS proxy. I cannot send ICMP packets because there is a proxy in between the hosts. I'm sure there are many other diagnostic use cases for this. Perhaps there are also other applications that for some reason want to show the connection latency, like 3D shooters typically can do, for example.

In any case, I think this is a useful feature for russh to have, so here I am proposing it, with this PR.