### PR TITLE
Addresses race condition from #226

### DIFF
--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -869,11 +869,12 @@ pub trait Server {
                     },
                     accept_result = socket.accept() => {
                         match accept_result {
-                            Ok((socket, _)) => {
+                            Ok((socket, peer_addr)) => {
                                 let mut shutdown_rx = shutdown_tx2.subscribe();
 
                                 let config = config.clone();
-                                let handler = self.new_client(socket.peer_addr().ok());
+                                // NOTE: For backwards compatibility, we keep the Option signature as changing it would be a breaking change.
+                                let handler = self.new_client(Some(peer_addr));
                                 let error_tx = error_tx.clone();
 
                                 russh_util::runtime::spawn(async move {


### PR DESCRIPTION
#226 identified a race condition where if a client tears down the socket before our handler is scheduled to run on the CPU again, self.new_client would receive a None value as the peer address. This PR fixes this by using the value provided by tokio and passing that to the self.new_client call wrapped in Some() to keep the API from breaking.

Such behaviour is not coming from normal clients but rather misbehaving bots that scan ports with very agressive timings.

Later PR's or if required this one, could also change the API to remove the Option from new_client but this would be a breaking change and to allow the maximum number of people to benefit from this patchm this should be done in a seperate PR.

If possible I do not want to appear in the ".all-contributorsrc" file as this is such a miniscule change, that in my opinion, it does not warrant adding me there