### PR TITLE
[FIX] Ignore window adjustment after channel EOF

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -542,7 +542,7 @@ impl Session {
                         new_size = channel.recipient_window_size.saturating_add(amount);
                         channel.recipient_window_size = new_size;
                     } else {
-                        return Err(crate::Error::WrongChannel.into());
+                        return Ok(());
                     }
                 }
 

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -662,7 +662,7 @@ impl Session {
                         new_size = channel.recipient_window_size.saturating_add(amount);
                         channel.recipient_window_size = new_size;
                     } else {
-                        return Err(Error::WrongChannel.into());
+                        return Ok(());
                     }
                 }
                 if let Some(ref mut enc) = self.common.encrypted {


### PR DESCRIPTION
Closes #575.

I don't know if this is the ideal fix, compared to, say, a check on whether the channel existed briefly before the message is handled, but it appears to fix the original issue.