### PR TITLE
[FIX] Remove `ring` feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,7 +51,7 @@ jobs:
         rustup target add --toolchain 1.81.0 wasm32-wasip1
 
     - name: Build (WASM-compatible features)
-      run: cargo +1.81.0 build --verbose --target wasm32-wasip1 --no-default-features --features flate2,ring -p russh
+      run: cargo +1.81.0 build --verbose --target wasm32-wasip1 --no-default-features --features flate2 -p russh
 
   Formatting:
     runs-on: ubuntu-24.04

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -21,7 +21,6 @@ legacy-ed25519-pkcs8-parser = ["yasna"]
 des = ["dep:des"]
 # Danger: DSA algorithm is insecure.
 dsa = ["ssh-key/dsa"]
-ring = ["dep:ring"]
 rsa = ["dep:rsa", "dep:pkcs1", "ssh-key/rsa", "ssh-key/rsa-sha1"]
 _bench = ["dep:criterion"]
 
@@ -66,7 +65,7 @@ pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption"] }
 rand_core = { version = "0.6.4", features = ["getrandom", "std"] }
 rand.workspace = true
-ring = { version = "0.17.14", optional = true }
+ring = "0.17.14"
 rsa = { version = "0.9", optional = true }
 russh-cryptovec = { version = "0.52.0", path = "../cryptovec", features = [
   "ssh-encoding",

--- a/russh/src/cipher/chacha20poly1305.rs
+++ b/russh/src/cipher/chacha20poly1305.rs
@@ -17,7 +17,7 @@
 
 #[cfg(feature = "aws-lc-rs")]
 use aws_lc_rs::aead::chacha20_poly1305_openssh;
-#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+#[cfg(not(feature = "aws-lc-rs"))]
 use ring::aead::chacha20_poly1305_openssh;
 
 use super::super::Error;

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -26,7 +26,7 @@ use aws_lc_rs::{
     error::Unspecified,
 };
 use rand::RngCore;
-#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+#[cfg(not(feature = "aws-lc-rs"))]
 use ring::{
     aead::{
         Aad, Algorithm, BoundKey, Nonce as AeadNonce, NonceSequence, OpeningKey as AeadOpeningKey,

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -29,7 +29,7 @@ use ctr::Ctr128BE;
 use delegate::delegate;
 use log::trace;
 use once_cell::sync::Lazy;
-#[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
+#[cfg(not(feature = "aws-lc-rs"))]
 use ring::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use ssh_encoding::Encode;
 use tokio::io::{AsyncRead, AsyncReadExt};

--- a/russh/src/keys/format/pkcs5.rs
+++ b/russh/src/keys/format/pkcs5.rs
@@ -36,6 +36,7 @@ pub fn decode_pkcs5(
         }
         #[cfg(not(feature = "rsa"))]
         {
+            let _ = sec;
             Err(Error::UnsupportedKeyType {
                 key_type_string: "RSA".to_string(),
                 key_type_raw: vec![],


### PR DESCRIPTION
This is an alternative to #569, proposed in [this comment](https://github.com/Eugeny/russh/pull/569#issuecomment-3383547343). This removes the `ring` flag, making the crate the default backend when the `aws-lc-rs` feature is disabled. This way, there will always be exactly one crypto backend available.

Sadly, as per https://github.com/rust-lang/cargo/issues/2980, there is no way to set mutually-exclusive features as of yet, which means that ring always gets pulled even when it's not used.