### PR TITLE
Update generic-array from 0.14 to 1.x

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -48,7 +48,7 @@ elliptic-curve = { version = "0.13", features = ["ecdh"] }
 enum_dispatch = "0.3.13"
 flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
-generic-array = "0.14"
+generic-array = { version = "1.3.3", features = ["compat-0_14"] }
 getrandom = { version = "0.2.15", features = ["js"] }
 hex-literal = "0.4"
 hmac.workspace = true

--- a/russh/src/kex/curve25519.rs
+++ b/russh/src/kex/curve25519.rs
@@ -139,7 +139,7 @@ impl KexAlgorithmImplementor for Curve25519Kex {
         hasher.update(&buffer);
 
         let mut res = CryptoVec::new();
-        res.extend(hasher.finalize().as_slice());
+        res.extend(&hasher.finalize());
         Ok(res)
     }
 

--- a/russh/src/kex/dh/mod.rs
+++ b/russh/src/kex/dh/mod.rs
@@ -296,7 +296,7 @@ impl<D: Digest> KexAlgorithmImplementor for DhGroupKex<D> {
         hasher.update(&buffer);
 
         let mut res = CryptoVec::new();
-        res.extend(hasher.finalize().as_slice());
+        res.extend(&hasher.finalize());
         Ok(res)
     }
 

--- a/russh/src/kex/ecdh_nistp.rs
+++ b/russh/src/kex/ecdh_nistp.rs
@@ -173,7 +173,7 @@ where
         hasher.update(&buffer);
 
         let mut res = CryptoVec::new();
-        res.extend(hasher.finalize().as_slice());
+        res.extend(&hasher.finalize());
         Ok(res)
     }
 

--- a/russh/src/kex/hybrid_mlkem.rs
+++ b/russh/src/kex/hybrid_mlkem.rs
@@ -196,13 +196,13 @@ impl KexAlgorithmImplementor for MlKem768X25519Kex {
         hasher.update(&combined);
         let k = hasher.finalize();
 
-        k.as_slice().encode(buffer)?;
+        (*k).encode(buffer)?;
 
         let mut hasher = sha2::Sha256::new();
         hasher.update(&buffer);
 
         let mut res = CryptoVec::new();
-        res.extend(hasher.finalize().as_slice());
+        res.extend(&hasher.finalize());
         Ok(res)
     }
 
@@ -226,7 +226,7 @@ impl KexAlgorithmImplementor for MlKem768X25519Kex {
         hasher.update(&combined);
         let k = hasher.finalize();
 
-        let shared_secret = SharedSecret::from_string(k.as_slice())?;
+        let shared_secret = SharedSecret::from_string(&k)?;
 
         compute_keys::<sha2::Sha256>(
             Some(&shared_secret),


### PR DESCRIPTION
cargo clippy suggests the upgrade to generic-array 1.x, so this change migrates from deprecated generic-array 0.14 to 1.3.3 while maintaining compatibility with RustCrypto dependencies that still use 0.14.

Relevant changes:
 - Add compat-0_14 feature to generic-array for 0.14 compatibility
 - Update ArrayLength trait bounds: <u8> not needed
 - Use digest::generic_array for cipher/mac which uses 0.14 types
 - Replace clone_from_slice() with copy_from_slice()
 - Add OutputSizeUser trait bound to enable GenericArray with M::OutputSize