### PR TITLE
Remove unneeded deps

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -58,7 +58,6 @@ log.workspace = true
 md5 = "0.7"
 num-bigint = { version = "0.4.2", features = ["rand"] }
 # num-integer = "0.1"
-once_cell = "1.13"
 p256 = { version = "0.13", features = ["ecdh"] }
 p384 = { version = "0.13", features = ["ecdh"] }
 p521 = { version = "0.13", features = ["ecdh"] }
@@ -90,7 +89,6 @@ yasna = { version = "0.5.0", features = [
   "num-bigint",
 ], optional = true }
 zeroize = "1.7"
-base64ct = "~1.6" # can be removed in 2024 edition
 criterion = { version = "0.3", optional = true, features = ["html_reports"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -20,6 +20,7 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::num::Wrapping;
+use std::sync::LazyLock;
 
 use aes::{Aes128, Aes192, Aes256};
 #[cfg(feature = "aws-lc-rs")]
@@ -28,16 +29,15 @@ use byteorder::{BigEndian, ByteOrder};
 use ctr::Ctr128BE;
 use delegate::delegate;
 use log::trace;
-use once_cell::sync::Lazy;
 #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
 use ring::aead::{AES_128_GCM as ALGORITHM_AES_128_GCM, AES_256_GCM as ALGORITHM_AES_256_GCM};
 use ssh_encoding::Encode;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
 use self::cbc::CbcWrapper;
+use crate::Error;
 use crate::mac::MacAlgorithm;
 use crate::sshbuffer::SSHBuffer;
-use crate::Error;
 
 pub(crate) mod block;
 pub(crate) mod cbc;
@@ -129,8 +129,8 @@ pub static ALL_CIPHERS: &[&Name] = &[
     &CHACHA20_POLY1305,
 ];
 
-pub(crate) static CIPHERS: Lazy<HashMap<&'static Name, &(dyn Cipher + Send + Sync)>> =
-    Lazy::new(|| {
+pub(crate) static CIPHERS: LazyLock<HashMap<&'static Name, &(dyn Cipher + Send + Sync)>> =
+    LazyLock::new(|| {
         let mut h: HashMap<&'static Name, &(dyn Cipher + Send + Sync)> = HashMap::new();
         h.insert(&CLEAR, &_CLEAR);
         h.insert(&NONE, &_CLEAR);

--- a/russh/src/kex/mod.rs
+++ b/russh/src/kex/mod.rs
@@ -24,20 +24,20 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::Debug;
+use std::sync::LazyLock;
 
 use curve25519::Curve25519KexType;
 use delegate::delegate;
 use dh::groups::DhGroup;
 use dh::{
-    DhGexSha1KexType, DhGexSha256KexType, DhGroup14Sha1KexType, DhGroup14Sha256KexType,
-    DhGroup15Sha512KexType, DhGroup16Sha512KexType, DhGroup17Sha512KexType, DhGroup18Sha512KexType,
-    DhGroup1Sha1KexType,
+    DhGexSha1KexType, DhGexSha256KexType, DhGroup1Sha1KexType, DhGroup14Sha1KexType,
+    DhGroup14Sha256KexType, DhGroup15Sha512KexType, DhGroup16Sha512KexType, DhGroup17Sha512KexType,
+    DhGroup18Sha512KexType,
 };
 use digest::Digest;
 use ecdh_nistp::{EcdhNistP256KexType, EcdhNistP384KexType, EcdhNistP521KexType};
 use enum_dispatch::enum_dispatch;
 use hybrid_mlkem::MlKem768X25519KexType;
-use once_cell::sync::Lazy;
 use p256::NistP256;
 use p384::NistP384;
 use p521::NistP521;
@@ -50,7 +50,7 @@ use crate::cipher::CIPHERS;
 use crate::client::GexParams;
 use crate::mac::{self, MACS};
 use crate::session::{Exchange, NewKeys};
-use crate::{cipher, CryptoVec, Error};
+use crate::{CryptoVec, Error, cipher};
 
 #[derive(Debug)]
 pub(crate) enum SessionKexState<K> {
@@ -296,8 +296,8 @@ pub const ALL_KEX_ALGORITHMS: &[&Name] = &[
     &NONE,
 ];
 
-pub(crate) static KEXES: Lazy<HashMap<&'static Name, &(dyn KexType + Send + Sync)>> =
-    Lazy::new(|| {
+pub(crate) static KEXES: LazyLock<HashMap<&'static Name, &(dyn KexType + Send + Sync)>> =
+    LazyLock::new(|| {
         let mut h: HashMap<&'static Name, &(dyn KexType + Send + Sync)> = HashMap::new();
         h.insert(&MLKEM768X25519_SHA256, &_MLKEM768X25519_SHA256);
         h.insert(&CURVE25519, &_CURVE25519);

--- a/russh/src/mac/mod.rs
+++ b/russh/src/mac/mod.rs
@@ -16,11 +16,11 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::marker::PhantomData;
+use std::sync::LazyLock;
 
 use delegate::delegate;
 use digest::typenum::{U20, U32, U64};
 use hmac::Hmac;
-use once_cell::sync::Lazy;
 use sha1::Sha1;
 use sha2::{Sha256, Sha512};
 use ssh_encoding::Encode;
@@ -108,8 +108,8 @@ pub const ALL_MAC_ALGORITHMS: &[&Name] = &[
     &HMAC_SHA512_ETM,
 ];
 
-pub(crate) static MACS: Lazy<HashMap<&'static Name, &(dyn MacAlgorithm + Send + Sync)>> =
-    Lazy::new(|| {
+pub(crate) static MACS: LazyLock<HashMap<&'static Name, &(dyn MacAlgorithm + Send + Sync)>> =
+    LazyLock::new(|| {
         let mut h: HashMap<&'static Name, &(dyn MacAlgorithm + Send + Sync)> = HashMap::new();
         h.insert(&NONE, &_NONE);
         h.insert(&HMAC_SHA1, &_HMAC_SHA1);


### PR DESCRIPTION
* base64ct is removed, as russh is now using 2024 edition, although its not clear why it was added [here](https://github.com/Eugeny/russh/pull/523) in the first place.
* once_cell is removed, we can use LazyLock instead, which was added in rust 1.80

I raised https://github.com/Eugeny/russh/pull/596 to address the CI failure