### PR TITLE
Fix clippy lints to fix CI

### DIFF
--- a/cryptovec/src/cryptovec.rs
+++ b/cryptovec/src/cryptovec.rs
@@ -238,7 +238,7 @@ impl CryptoVec {
                 if self.p.is_null() {
                     #[allow(clippy::panic)]
                     {
-                        panic!("Realloc failed, pointer = {:?} {:?}", self, size)
+                        panic!("Realloc failed, pointer = {self:?} {size:?}")
                     }
                 } else {
                     self.capacity = next_capacity;

--- a/cryptovec/src/platform/mod.rs
+++ b/cryptovec/src/platform/mod.rs
@@ -35,8 +35,7 @@ mod error {
             let warning_previously_shown = MLOCK_WARNING_SHOWN.swap(true, Ordering::Relaxed);
             if !warning_previously_shown {
                 warn!(
-                    "Security warning: OS has failed to lock/unlock memory for a cryptographic buffer: {}",
-                    message
+                    "Security warning: OS has failed to lock/unlock memory for a cryptographic buffer: {message}"
                 );
                 #[cfg(unix)]
                 warn!("You might need to increase the RLIMIT_MEMLOCK limit.");

--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -281,7 +281,7 @@ fn parse_ssh_config(contents: &str) -> Result<SshConfig, Error> {
                     _ => config.strict_host_key_checking = Some(true),
                 },
                 key => {
-                    debug!("{:?}", key);
+                    debug!("{key:?}");
                 }
             }
         }

--- a/russh/examples/client_exec_interactive.rs
+++ b/russh/examples/client_exec_interactive.rs
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
         .await?
     };
 
-    println!("Exitcode: {:?}", code);
+    println!("Exitcode: {code:?}");
     ssh.close().await?;
     Ok(())
 }

--- a/russh/examples/client_exec_simple.rs
+++ b/russh/examples/client_exec_simple.rs
@@ -48,7 +48,7 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    println!("Exitcode: {:?}", code);
+    println!("Exitcode: {code:?}");
     ssh.close().await?;
     Ok(())
 }

--- a/russh/examples/client_open_direct_tcpip.rs
+++ b/russh/examples/client_open_direct_tcpip.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
     info!("Server: {}:{} Connected", cli.host, cli.port);
 
     let (socket, o_addr) = listener.accept().await?;
-    info!("originator address: {}", o_addr);
+    info!("originator address: {o_addr}");
     ssh.call(socket, o_addr, forward_addr).await?;
 
     ssh.close().await?;

--- a/russh/examples/echoserver.rs
+++ b/russh/examples/echoserver.rs
@@ -70,7 +70,7 @@ impl server::Server for Server {
         s
     }
     fn handle_session_error(&mut self, _error: <Self::Handler as russh::server::Handler>::Error) {
-        eprintln!("Session error: {:#?}", _error);
+        eprintln!("Session error: {_error:#?}");
     }
 }
 

--- a/russh/examples/ratatui_app.rs
+++ b/russh/examples/ratatui_app.rs
@@ -38,7 +38,7 @@ impl TerminalHandle {
             while let Some(data) = receiver.recv().await {
                 let result = handle.data(channel_id, data.into()).await;
                 if result.is_err() {
-                    eprintln!("Failed to send data: {:?}", result);
+                    eprintln!("Failed to send data: {result:?}");
                 }
             }
         });

--- a/russh/examples/ratatui_shared_app.rs
+++ b/russh/examples/ratatui_shared_app.rs
@@ -38,7 +38,7 @@ impl TerminalHandle {
             while let Some(data) = receiver.recv().await {
                 let result = handle.data(channel_id, data.into()).await;
                 if result.is_err() {
-                    eprintln!("Failed to send data: {:?}", result);
+                    eprintln!("Failed to send data: {result:?}");
                 }
             }
         });

--- a/russh/examples/sftp_client.rs
+++ b/russh/examples/sftp_client.rs
@@ -16,7 +16,7 @@ impl client::Handler for Client {
         &mut self,
         server_public_key: &ssh_key::PublicKey,
     ) -> Result<bool, Self::Error> {
-        info!("check_server_key: {:?}", server_public_key);
+        info!("check_server_key: {server_public_key:?}");
         Ok(true)
     }
 

--- a/russh/examples/sftp_server.rs
+++ b/russh/examples/sftp_server.rs
@@ -44,7 +44,7 @@ impl russh::server::Handler for SshSession {
     type Error = anyhow::Error;
 
     async fn auth_password(&mut self, user: &str, password: &str) -> Result<Auth, Self::Error> {
-        info!("credentials: {}, {}", user, password);
+        info!("credentials: {user}, {password}");
         Ok(Auth::Accept)
     }
 
@@ -53,7 +53,7 @@ impl russh::server::Handler for SshSession {
         user: &str,
         public_key: &russh::keys::ssh_key::PublicKey,
     ) -> Result<Auth, Self::Error> {
-        info!("credentials: {}, {:?}", user, public_key);
+        info!("credentials: {user}, {public_key:?}");
         Ok(Auth::Accept)
     }
 
@@ -86,7 +86,7 @@ impl russh::server::Handler for SshSession {
         name: &str,
         session: &mut Session,
     ) -> Result<(), Self::Error> {
-        info!("subsystem: {}", name);
+        info!("subsystem: {name}");
 
         if name == "sftp" {
             let channel = self.get_channel(channel_id).await;
@@ -139,13 +139,13 @@ impl russh_sftp::server::Handler for SftpSession {
     }
 
     async fn opendir(&mut self, id: u32, path: String) -> Result<Handle, Self::Error> {
-        info!("opendir: {}", path);
+        info!("opendir: {path}");
         self.root_dir_read_done = false;
         Ok(Handle { id, handle: path })
     }
 
     async fn readdir(&mut self, id: u32, handle: String) -> Result<Name, Self::Error> {
-        info!("readdir handle: {}", handle);
+        info!("readdir handle: {handle}");
         if handle == "/" && !self.root_dir_read_done {
             self.root_dir_read_done = true;
             return Ok(Name {
@@ -161,7 +161,7 @@ impl russh_sftp::server::Handler for SftpSession {
     }
 
     async fn realpath(&mut self, id: u32, path: String) -> Result<Name, Self::Error> {
-        info!("realpath: {}", path);
+        info!("realpath: {path}");
         Ok(Name {
             id,
             files: vec![File::dummy("/")],

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -22,9 +22,9 @@ use ssh_key::{Certificate, HashAlg, PrivateKey};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+use crate::CryptoVec;
 use crate::helpers::NameList;
 use crate::keys::PrivateKeyWithHashAlg;
-use crate::CryptoVec;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MethodKind {
@@ -195,6 +195,7 @@ impl<R: AsyncRead + AsyncWrite + Unpin + Send + 'static> Signer
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Method {
     None,
     Password {

--- a/russh/src/cert.rs
+++ b/russh/src/cert.rs
@@ -1,13 +1,14 @@
 use ssh_key::{Certificate, HashAlg, PublicKey};
 #[cfg(not(target_arch = "wasm32"))]
 use {
-    crate::helpers::AlgorithmExt, ssh_encoding::Decode, ssh_key::public::KeyData,
-    ssh_key::Algorithm,
+    crate::helpers::AlgorithmExt, ssh_encoding::Decode, ssh_key::Algorithm,
+    ssh_key::public::KeyData,
 };
 
 use crate::keys::key::PrivateKeyWithHashAlg;
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum PublicKeyOrCertificate {
     PublicKey {
         key: PublicKey,

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -217,9 +217,9 @@ pub(crate) trait SealingKey {
         trace!("writing, seqn = {:?}", buffer.seqn.0);
 
         let padding_length = self.padding_length(payload);
-        trace!("padding length {:?}", padding_length);
+        trace!("padding length {padding_length:?}");
         let packet_length = PADDING_LENGTH_LEN + payload.len() + padding_length;
-        trace!("packet_length {:?}", packet_length);
+        trace!("packet_length {packet_length:?}");
         let offset = buffer.buffer.len();
 
         // Maximum packet length:
@@ -256,12 +256,12 @@ pub(crate) async fn read<R: AsyncRead + Unpin>(
         let mut len = vec![0; cipher.packet_length_to_read_for_block_length()];
 
         stream.read_exact(&mut len).await?;
-        trace!("reading, len = {:?}", len);
+        trace!("reading, len = {len:?}");
         {
             let seqn = buffer.seqn.0;
             buffer.buffer.clear();
             buffer.buffer.extend(&len);
-            trace!("reading, seqn = {:?}", seqn);
+            trace!("reading, seqn = {seqn:?}");
             let len = cipher.decrypt_packet_length(seqn, &len);
             let len = BigEndian::read_u32(&len) as usize;
 
@@ -287,7 +287,7 @@ pub(crate) async fn read<R: AsyncRead + Unpin>(
     let plaintext = cipher.open(seqn, &mut buffer.buffer)?;
 
     let padding_length = *plaintext.first().to_owned().unwrap_or(&0) as usize;
-    trace!("reading, padding_length {:?}", padding_length);
+    trace!("reading, padding_length {padding_length:?}");
     let plaintext_end = plaintext
         .len()
         .checked_sub(padding_length)

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -536,7 +536,7 @@ impl Session {
                 let channel_num = map_err!(ChannelId::decode(&mut r))?;
                 let amount = map_err!(u32::decode(&mut r))?;
                 let mut new_size = 0;
-                debug!("channel_window_adjust amount: {:?}", amount);
+                debug!("channel_window_adjust amount: {amount:?}");
                 if let Some(ref mut enc) = self.common.encrypted {
                     if let Some(ref mut channel) = enc.channels.get_mut(&channel_num) {
                         new_size = channel.recipient_window_size.saturating_add(amount);
@@ -633,7 +633,7 @@ impl Session {
                     };
 
                     let confirm = || {
-                        debug!("confirming channel: {:?}", msg);
+                        debug!("confirming channel: {msg:?}");
                         map_err!(msg.confirm(
                             &mut enc.write,
                             id.0,
@@ -811,7 +811,7 @@ impl Session {
                 Ok(())
             }
             m => {
-                debug!("unknown message received: {:?}", m);
+                debug!("unknown message received: {m:?}");
                 Ok(())
             }
         }
@@ -862,8 +862,7 @@ impl Session {
                 EncryptedState::InitCompression | EncryptedState::Authenticated => false,
             };
             debug!(
-                "write_auth_request_if_needed: is_waiting = {:?}",
-                is_waiting
+                "write_auth_request_if_needed: is_waiting = {is_waiting:?}"
             );
             if is_waiting {
                 enc.write_auth_request(user, &meth)?;

--- a/russh/src/client/kex.rs
+++ b/russh/src/client/kex.rs
@@ -196,7 +196,7 @@ impl ClientKex {
 
                 let prime = Mpint::decode(&mut r)?;
                 let generator = Mpint::decode(&mut r)?;
-                debug!("received gex group: prime={}, generator={}", prime, generator);
+                debug!("received gex group: prime={prime}, generator={generator}");
 
                 let group = DhGroup {
                     prime: prime.as_bytes().to_vec().into(),

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -42,8 +42,8 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
-use futures::task::{Context, Poll};
 use futures::Future;
+use futures::task::{Context, Poll};
 use kex::ClientKex;
 use log::{debug, error, trace, warn};
 use russh_util::time::Instant;
@@ -52,7 +52,7 @@ use ssh_key::{Algorithm, Certificate, HashAlg, PrivateKey, PublicKey};
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt, ReadHalf, WriteHalf};
 use tokio::pin;
 use tokio::sync::mpsc::{
-    channel, unbounded_channel, Receiver, Sender, UnboundedReceiver, UnboundedSender,
+    Receiver, Sender, UnboundedReceiver, UnboundedSender, channel, unbounded_channel,
 };
 use tokio::sync::oneshot;
 
@@ -60,7 +60,7 @@ pub use crate::auth::AuthResult;
 use crate::channels::{
     Channel, ChannelMsg, ChannelReadHalf, ChannelRef, ChannelWriteHalf, WindowSizeRef,
 };
-use crate::cipher::{self, clear, OpeningKey};
+use crate::cipher::{self, OpeningKey, clear};
 use crate::kex::{KexCause, KexProgress, SessionKexState};
 use crate::keys::PrivateKeyWithHashAlg;
 use crate::msg::{is_kex_msg, validate_server_msg_strict_kex};
@@ -68,8 +68,8 @@ use crate::session::{CommonSession, EncryptedState, GlobalRequestResponse, NewKe
 use crate::ssh_read::SshRead;
 use crate::sshbuffer::{IncomingSshPacket, PacketWriter, SSHBuffer, SshId};
 use crate::{
-    auth, map_err, msg, negotiation, ChannelId, ChannelOpenFailure, CryptoVec, Disconnect, Error,
-    Limits, MethodSet, Sig,
+    ChannelId, ChannelOpenFailure, CryptoVec, Disconnect, Error, Limits, MethodSet, Sig, auth,
+    map_err, msg, negotiation,
 };
 
 mod encrypted;
@@ -127,6 +127,7 @@ enum Reply {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub enum Msg {
     Authenticate {
         user: String,
@@ -359,7 +360,7 @@ impl<H: Handler> Handle<H> {
                     return Ok(KeyboardInteractiveAuthResponse::Failure {
                         remaining_methods,
                         partial_success,
-                    })
+                    });
                 }
                 Some(Reply::AuthInfoRequest {
                     name,
@@ -389,13 +390,13 @@ impl<H: Handler> Handle<H> {
                     return Ok(AuthResult::Failure {
                         remaining_methods,
                         partial_success,
-                    })
+                    });
                 }
                 None => {
                     return Ok(AuthResult::Failure {
                         remaining_methods: MethodSet::empty(),
                         partial_success: false,
-                    })
+                    });
                 }
                 _ => {}
             }
@@ -476,7 +477,7 @@ impl<H: Handler> Handle<H> {
                     return Ok(AuthResult::Failure {
                         remaining_methods,
                         partial_success,
-                    })
+                    });
                 }
                 Some(Reply::SignRequest { key, data }) => {
                     let data = signer.auth_publickey_sign(&key, hash_alg, data).await;
@@ -492,7 +493,7 @@ impl<H: Handler> Handle<H> {
                     return Ok(AuthResult::Failure {
                         remaining_methods: MethodSet::empty(),
                         partial_success: false,
-                    })
+                    });
                 }
                 _ => {}
             }
@@ -532,7 +533,7 @@ impl<H: Handler> Handle<H> {
                     return Err(crate::Error::Disconnect);
                 }
                 msg => {
-                    debug!("msg = {:?}", msg);
+                    debug!("msg = {msg:?}");
                 }
             }
         }
@@ -1610,19 +1611,22 @@ impl GexParams {
 
     pub(crate) fn validate(&self) -> Result<(), Error> {
         if self.min_group_size < 2048 {
-            return Err(Error::InvalidConfig(
-                format!("min_group_size must be at least 2048 bits. We got {} bits", self.min_group_size),
-            ));
+            return Err(Error::InvalidConfig(format!(
+                "min_group_size must be at least 2048 bits. We got {} bits",
+                self.min_group_size
+            )));
         }
         if self.preferred_group_size < self.min_group_size {
-            return Err(Error::InvalidConfig(
-                format!("preferred_group_size must be at least as large as min_group_size. We have preferred_group_size = {} < min_group_size = {}", self.preferred_group_size, self.min_group_size),
-            ));
+            return Err(Error::InvalidConfig(format!(
+                "preferred_group_size must be at least as large as min_group_size. We have preferred_group_size = {} < min_group_size = {}",
+                self.preferred_group_size, self.min_group_size
+            )));
         }
         if self.max_group_size < self.preferred_group_size {
-            return Err(Error::InvalidConfig(
-                format!("max_group_size must be at least as large as preferred_group_size. We have max_group_size = {} < preferred_group_size = {}", self.max_group_size, self.preferred_group_size),
-            ));
+            return Err(Error::InvalidConfig(format!(
+                "max_group_size must be at least as large as preferred_group_size. We have max_group_size = {} < preferred_group_size = {}",
+                self.max_group_size, self.preferred_group_size
+            )));
         }
         Ok(())
     }
@@ -2007,7 +2011,7 @@ pub trait Handler: Sized + Send {
         session: &mut Session,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async move {
-            debug!("openssh_ext_hostkeys_announced: {:?}", keys);
+            debug!("openssh_ext_hostkeys_announced: {keys:?}");
             Ok(())
         }
     }
@@ -2021,7 +2025,7 @@ pub trait Handler: Sized + Send {
         reason: DisconnectReason<Self::Error>,
     ) -> impl Future<Output = Result<(), Self::Error>> + Send {
         async {
-            debug!("disconnected: {:?}", reason);
+            debug!("disconnected: {reason:?}");
             match reason {
                 DisconnectReason::ReceivedDisconnect(_) => Ok(()),
                 DisconnectReason::Error(e) => Err(e),

--- a/russh/src/client/test.rs
+++ b/russh/src/client/test.rs
@@ -116,7 +116,7 @@ mod tests {
                 .unwrap();
         });
 
-        println!("Server listening on {}", addr);
+        println!("Server listening on {addr}");
 
         // Configure the client
         let client_config = Arc::new(Config::default());
@@ -155,7 +155,7 @@ mod tests {
             crate::channels::ChannelMsg::Data { data: msg_data } => {
                 assert_eq!(test_data.as_slice(), &msg_data[..]);
             }
-            msg => panic!("Unexpected message {:?}", msg),
+            msg => panic!("Unexpected message {msg:?}"),
         }
     }
 }

--- a/russh/src/kex/dh/mod.rs
+++ b/russh/src/kex/dh/mod.rs
@@ -183,7 +183,7 @@ impl<D: Digest> KexAlgorithmImplementor for DhGroupKex<D> {
                 .ok_or(Error::Inconsistent)?
         };
 
-        trace!("client_pubkey: {:?}", client_pubkey);
+        trace!("client_pubkey: {client_pubkey:?}");
 
         dh.generate_private_key(true);
         let server_pubkey = &dh.generate_public_key();

--- a/russh/src/keys/agent/client.rs
+++ b/russh/src/keys/agent/client.rs
@@ -289,7 +289,7 @@ impl<S: AgentStream + Unpin> AgentClient<S> {
         hash_alg: Option<HashAlg>,
         mut data: CryptoVec,
     ) -> Result<CryptoVec, Error> {
-        debug!("sign_request: {:?}", data);
+        debug!("sign_request: {data:?}");
         let hash = self.prepare_sign_request(public, hash_alg, &data)?;
 
         self.read_response().await?;
@@ -318,7 +318,7 @@ impl<S: AgentStream + Unpin> AgentClient<S> {
         msg::SIGN_REQUEST.encode(&mut self.buf)?;
         public.key_data().encoded()?.encode(&mut self.buf)?;
         data.encode(&mut self.buf)?;
-        debug!("public = {:?}", public);
+        debug!("public = {public:?}");
 
         let hash = match public.algorithm() {
             Algorithm::Rsa { .. } => match hash_alg {
@@ -350,7 +350,7 @@ impl<S: AgentStream + Unpin> AgentClient<S> {
             sig.encode(data)?;
             Ok(())
         } else {
-            error!("unexpected agent signature type: {:?}", t);
+            error!("unexpected agent signature type: {t:?}");
             Err(Error::AgentProtocolError)
         }
     }
@@ -362,7 +362,7 @@ impl<S: AgentStream + Unpin> AgentClient<S> {
         hash_alg: Option<HashAlg>,
         data: &[u8],
     ) -> impl futures::Future<Output = (Self, Result<String, Error>)> {
-        debug!("sign_request: {:?}", data);
+        debug!("sign_request: {data:?}");
         let r = self.prepare_sign_request(public, hash_alg, data);
         async move {
             if let Err(e) = r {
@@ -391,7 +391,7 @@ impl<S: AgentStream + Unpin> AgentClient<S> {
         hash_alg: Option<HashAlg>,
         data: &[u8],
     ) -> Result<Signature, Error> {
-        debug!("sign_request: {:?}", data);
+        debug!("sign_request: {data:?}");
 
         self.prepare_sign_request(public, hash_alg, data)?;
         self.read_response().await?;

--- a/russh/src/keys/agent/server.rs
+++ b/russh/src/keys/agent/server.rs
@@ -320,7 +320,7 @@ impl<S: AsyncRead + AsyncWrite + Send + Unpin + 'static, A: Agent + Send + Sync 
             let blob = Bytes::decode(r)?;
             let k = self.keys.0.read().or(Err(Error::AgentFailure))?;
             if let Some((key, _, constraints)) = k.get(&blob.to_vec()) {
-                if constraints.iter().any(|c| *c == Constraint::Confirm) {
+                if constraints.contains(&Constraint::Confirm) {
                     needs_confirm = true;
                 }
                 key.clone()

--- a/russh/src/keys/format/tests.rs
+++ b/russh/src/keys/format/tests.rs
@@ -8,5 +8,5 @@ MIGkAgEBBDBNK0jwKqqf8zkM+Z2l++9r8bzdTS/XCoB4N1J07dPxpByyJyGbhvIy
 9dKW1tS+ywhejnKeu/48HXAXgx2g6qMJjEPpcTy/DaYm12r3GTaRzOBQmxSItStk
 lpQg5vf23Fc9fFrQ9AnQKrb1dgTkoxQ=
 -----END EC PRIVATE KEY-----"#;
-    decode_secret_key(&key, None).unwrap();
+    decode_secret_key(key, None).unwrap();
 }

--- a/russh/src/keys/known_hosts.rs
+++ b/russh/src/keys/known_hosts.rs
@@ -88,9 +88,9 @@ pub fn known_host_keys_path<P: AsRef<Path>>(
     let host_port = if port == 22 {
         Cow::Borrowed(host)
     } else {
-        Cow::Owned(format!("[{}]:{}", host, port))
+        Cow::Owned(format!("[{host}]:{port}"))
     };
-    debug!("host_port = {:?}", host_port);
+    debug!("host_port = {host_port:?}");
     let mut line = 1;
     let mut matches = vec![];
     while f.read_line(&mut buffer)? > 0 {
@@ -99,13 +99,13 @@ pub fn known_host_keys_path<P: AsRef<Path>>(
                 buffer.clear();
                 continue;
             }
-            debug!("line = {:?}", buffer);
+            debug!("line = {buffer:?}");
             let mut s = buffer.split(' ');
             let hosts = s.next();
             let _ = s.next();
             let key = s.next();
             if let (Some(h), Some(k)) = (hosts, key) {
-                debug!("{:?} {:?}", h, k);
+                debug!("{h:?} {k:?}");
                 if match_hostname(&host_port, h) {
                     matches.push((line, parse_public_key_base64(k)?));
                 }
@@ -175,9 +175,9 @@ pub fn learn_known_hosts_path<P: AsRef<Path>>(
         file.write_all(b"\n")?;
     }
     if port != 22 {
-        write!(file, "[{}]:{} ", host, port)?
+        write!(file, "[{host}]:{port} ")?
     } else {
-        write!(file, "{} ", host)?
+        write!(file, "{host} ")?
     }
     file.write_all(pubkey.to_openssh()?.as_bytes())?;
     file.write_all(b"\n")?;

--- a/russh/src/lib_inner.rs
+++ b/russh/src/lib_inner.rs
@@ -237,8 +237,7 @@ pub enum Error {
 
 pub(crate) fn strict_kex_violation(message_type: u8, sequence_number: usize) -> crate::Error {
     warn!(
-        "strict kex violated at sequence no. {:?}, message type: {:?}",
-        sequence_number, message_type
+        "strict kex violated at sequence no. {sequence_number:?}, message type: {message_type:?}"
     );
     crate::Error::StrictKeyExchangeViolation {
         message_type,

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -73,7 +73,7 @@ impl Session {
                 Some((&msg::SERVICE_REQUEST, mut r)),
             ) => {
                 let request = map_err!(String::decode(&mut r))?;
-                debug!("request: {:?}", request);
+                debug!("request: {request:?}");
                 if request == "ssh-userauth" {
                     let auth_request = server_accept_service(
                         handler.authentication_banner().await?,
@@ -263,7 +263,7 @@ impl Encrypted {
                 auth_user.push_str(&user);
                 let _ = map_err!(String::decode(r))?; // language_tag, deprecated.
                 let submethods = map_err!(String::decode(r))?;
-                debug!("{:?}", submethods);
+                debug!("{submethods:?}");
                 auth_request.current = Some(CurrentRequest::KeyboardInteractive {
                     submethods: submethods.to_string(),
                 });
@@ -321,7 +321,7 @@ impl Encrypted {
         // Parse the public key or certificate
         match key_or_cert {
             Ok(pk_or_cert) => {
-                debug!("is_real = {:?}", is_real);
+                debug!("is_real = {is_real:?}");
 
                 // Handle certificates specifically
                 let pubkey = match pk_or_cert {
@@ -437,7 +437,7 @@ impl Encrypted {
 
                             let mut algo = CryptoVec::new();
                             algo.extend(pubkey_algo.as_bytes());
-                            debug!("pubkey_key: {:?}", pubkey_key);
+                            debug!("pubkey_key: {pubkey_key:?}");
                             push_packet!(self.write, {
                                 self.write.push(msg::USERAUTH_PK_OK);
                                 map_err!(pubkey_algo.encode(&mut self.write))?;
@@ -486,7 +486,7 @@ async fn reject_auth_request(
     write: &mut CryptoVec,
     auth_request: &mut AuthRequest,
 ) -> Result<(), Error> {
-    debug!("rejecting {:?}", auth_request);
+    debug!("rejecting {auth_request:?}");
     push_packet!(write, {
         write.push(msg::USERAUTH_FAILURE);
         NameList::from(&auth_request.methods).encode(write)?;
@@ -597,7 +597,7 @@ impl Session {
                     enc.channels.remove(&channel_num);
                 }
                 self.channels.remove(&channel_num);
-                debug!("handler.channel_close {:?}", channel_num);
+                debug!("handler.channel_close {channel_num:?}");
                 handler.channel_close(channel_num, self).await
             }
             msg::CHANNEL_EOF => {
@@ -605,7 +605,7 @@ impl Session {
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.send(ChannelMsg::Eof).await.unwrap_or(())
                 }
-                debug!("handler.channel_eof {:?}", channel_num);
+                debug!("handler.channel_eof {channel_num:?}");
                 handler.channel_eof(channel_num, self).await
             }
             msg::CHANNEL_EXTENDED_DATA | msg::CHANNEL_DATA => {
@@ -616,7 +616,7 @@ impl Session {
                 } else {
                     Some(map_err!(u32::decode(r))?)
                 };
-                trace!("handler.data {:?} {:?}", ext, channel_num);
+                trace!("handler.data {ext:?} {channel_num:?}");
                 let data = map_err!(Bytes::decode(r))?;
                 let target = self.target_window_size;
 
@@ -673,7 +673,7 @@ impl Session {
                         .await
                         .unwrap_or(())
                 }
-                debug!("handler.window_adjusted {:?}", channel_num);
+                debug!("handler.window_adjusted {channel_num:?}");
                 handler.window_adjusted(channel_num, new_size, self).await
             }
 
@@ -703,7 +703,7 @@ impl Session {
                         .await
                         .unwrap_or(());
                 } else {
-                    error!("no channel for id {:?}", local_id);
+                    error!("no channel for id {local_id:?}");
                 }
                 handler
                     .channel_open_confirmation(
@@ -743,7 +743,7 @@ impl Session {
                                 }
                                 #[allow(clippy::indexing_slicing)] // length checked
                                 let num = BigEndian::read_u32(&mode_string[5 * i + 1..]);
-                                debug!("code = {:?}", code);
+                                debug!("code = {code:?}");
                                 if let Some(code) = Pty::from_u8(code) {
                                     #[allow(clippy::indexing_slicing)] // length checked
                                     if i < 130 {
@@ -752,7 +752,7 @@ impl Session {
                                         error!("pty-req: too many pty codes");
                                     }
                                 } else {
-                                    info!("pty-req: unknown pty code {:?}", code);
+                                    info!("pty-req: unknown pty code {code:?}");
                                 }
                                 i += 1
                             }
@@ -772,7 +772,7 @@ impl Session {
                                 .await;
                         }
 
-                        debug!("handler.pty_request {:?}", channel_num);
+                        debug!("handler.pty_request {channel_num:?}");
                         #[allow(clippy::indexing_slicing)] // `modes` length checked
                         handler
                             .pty_request(
@@ -804,7 +804,7 @@ impl Session {
                                 })
                                 .await;
                         }
-                        debug!("handler.x11_request {:?}", channel_num);
+                        debug!("handler.x11_request {channel_num:?}");
                         handler
                             .x11_request(
                                 channel_num,
@@ -830,7 +830,7 @@ impl Session {
                                 .await;
                         }
 
-                        debug!("handler.env_request {:?}", channel_num);
+                        debug!("handler.env_request {channel_num:?}");
                         handler
                             .env_request(channel_num, &env_variable, &env_value, self)
                             .await
@@ -841,7 +841,7 @@ impl Session {
                                 .send(ChannelMsg::RequestShell { want_reply: true })
                                 .await;
                         }
-                        debug!("handler.shell_request {:?}", channel_num);
+                        debug!("handler.shell_request {channel_num:?}");
                         handler.shell_request(channel_num, self).await
                     }
                     "auth-agent-req@openssh.com" => {
@@ -850,7 +850,7 @@ impl Session {
                                 .send(ChannelMsg::AgentForward { want_reply: true })
                                 .await;
                         }
-                        debug!("handler.agent_request {:?}", channel_num);
+                        debug!("handler.agent_request {channel_num:?}");
 
                         let response = handler.agent_request(channel_num, self).await?;
                         if response {
@@ -870,7 +870,7 @@ impl Session {
                                 })
                                 .await;
                         }
-                        debug!("handler.exec_request {:?}", channel_num);
+                        debug!("handler.exec_request {channel_num:?}");
                         handler.exec_request(channel_num, &req, self).await
                     }
                     "subsystem" => {
@@ -884,7 +884,7 @@ impl Session {
                                 })
                                 .await;
                         }
-                        debug!("handler.subsystem_request {:?}", channel_num);
+                        debug!("handler.subsystem_request {channel_num:?}");
                         handler.subsystem_request(channel_num, &name, self).await
                     }
                     "window-change" => {
@@ -904,7 +904,7 @@ impl Session {
                                 .await;
                         }
 
-                        debug!("handler.window_change {:?}", channel_num);
+                        debug!("handler.window_change {channel_num:?}");
                         handler
                             .window_change_request(
                                 channel_num,
@@ -925,7 +925,7 @@ impl Session {
                             .await
                             .unwrap_or(())
                         }
-                        debug!("handler.signal {:?} {:?}", channel_num, signal);
+                        debug!("handler.signal {channel_num:?} {signal:?}");
                         handler.signal(channel_num, signal, self).await
                     }
                     x => {
@@ -942,7 +942,7 @@ impl Session {
                     "tcpip-forward" => {
                         let address = map_err!(String::decode(r))?;
                         let port = map_err!(u32::decode(r))?;
-                        debug!("handler.tcpip_forward {:?} {:?}", address, port);
+                        debug!("handler.tcpip_forward {address:?} {port:?}");
                         let mut returned_port = port;
                         let result = handler
                             .tcpip_forward(&address, &mut returned_port, self)
@@ -964,7 +964,7 @@ impl Session {
                     "cancel-tcpip-forward" => {
                         let address = map_err!(String::decode(r))?;
                         let port = map_err!(u32::decode(r))?;
-                        debug!("handler.cancel_tcpip_forward {:?} {:?}", address, port);
+                        debug!("handler.cancel_tcpip_forward {address:?} {port:?}");
                         let result = handler.cancel_tcpip_forward(&address, port, self).await?;
                         if let Some(ref mut enc) = self.common.encrypted {
                             if result {
@@ -977,7 +977,7 @@ impl Session {
                     }
                     "streamlocal-forward@openssh.com" => {
                         let server_socket_path = map_err!(String::decode(r))?;
-                        debug!("handler.streamlocal_forward {:?}", server_socket_path);
+                        debug!("handler.streamlocal_forward {server_socket_path:?}");
                         let result = handler
                             .streamlocal_forward(&server_socket_path, self)
                             .await?;
@@ -992,7 +992,7 @@ impl Session {
                     }
                     "cancel-streamlocal-forward@openssh.com" => {
                         let socket_path = map_err!(String::decode(r))?;
-                        debug!("handler.cancel_streamlocal_forward {:?}", socket_path);
+                        debug!("handler.cancel_streamlocal_forward {socket_path:?}");
                         let result = handler
                             .cancel_streamlocal_forward(&socket_path, self)
                             .await?;
@@ -1088,7 +1088,7 @@ impl Session {
                 Ok(())
             }
             m => {
-                debug!("unknown message received: {:?}", m);
+                debug!("unknown message received: {m:?}");
                 Ok(())
             }
         }

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -174,7 +174,7 @@ impl ServerKex {
 
                 #[allow(clippy::indexing_slicing)] // length checked
                 let gex_params = GexParams::decode(&mut &input.buffer[1..])?;
-                debug!("client requests a gex group: {:?}", gex_params);
+                debug!("client requests a gex group: {gex_params:?}");
 
                 let Some(dh_group) = handler.lookup_dh_gex_group(&gex_params).await? else {
                     debug!("server::Handler impl did not find a matching DH group (is lookup_dh_gex_group implemented?)");
@@ -271,7 +271,7 @@ impl ServerKex {
                 })?;
 
                 // Hash signature
-                debug!("signing with key {:?}", key);
+                debug!("signing with key {key:?}");
                 let signature = sign_with_hash_alg(
                     &PrivateKeyWithHashAlg::new(Arc::new(key.clone()), signature_hash_alg),
                     &hash,

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -402,7 +402,7 @@ impl Handle {
                     return Err(Error::Disconnect);
                 }
                 msg => {
-                    debug!("msg = {:?}", msg);
+                    debug!("msg = {msg:?}");
                 }
             }
         }
@@ -585,7 +585,7 @@ impl Session {
                             self.exit_signal_request(id, signal_name, core_dumped, &error_message, &lang_tag)?;
                         }
                         Some(Msg::Channel(id, ChannelMsg::WindowAdjusted { new_size })) => {
-                            debug!("window adjusted to {:?} for channel {:?}", new_size, id);
+                            debug!("window adjusted to {new_size:?} for channel {id:?}");
                         }
                         Some(Msg::ChannelOpenAgent { channel_ref }) => {
                             let id = self.channel_open_agent()?;
@@ -837,7 +837,7 @@ impl Session {
                 assert!(channel.confirmed);
                 if channel.wants_reply {
                     channel.wants_reply = false;
-                    debug!("channel_success {:?}", channel);
+                    debug!("channel_success {channel:?}");
                     push_packet!(enc.write, {
                         msg::CHANNEL_SUCCESS.encode(&mut enc.write)?;
                         channel.recipient_channel.encode(&mut enc.write)?;

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -441,7 +441,7 @@ impl Encrypted {
                 channel.pending_data.push_back((buf0, None, buf_len))
             }
         } else {
-            debug!("{:?} not saved for this session", channel);
+            debug!("{channel:?} not saved for this session");
         }
         Ok(())
     }
@@ -480,7 +480,7 @@ impl Encrypted {
                 let len = BigEndian::read_u32(&self.write[self.write_cursor..]) as usize;
                 #[allow(clippy::indexing_slicing)]
                 let to_write = &self.write[(self.write_cursor + 4)..(self.write_cursor + 4 + len)];
-                trace!("session_write_encrypted, buf = {:?}", to_write);
+                trace!("session_write_encrypted, buf = {to_write:?}");
 
                 writer.packet_raw(to_write)?;
                 self.write_cursor += 4 + len

--- a/russh/src/ssh_read.rs
+++ b/russh/src/ssh_read.rs
@@ -122,7 +122,7 @@ impl<R: AsyncRead + Unpin> SshRead<R> {
 
             #[allow(clippy::indexing_slicing)] // length checked
             let n = AsyncReadExt::read(&mut self.r, &mut ssh_id.buf[ssh_id.total..]).await?;
-            trace!("read {:?}", n);
+            trace!("read {n:?}");
 
             ssh_id.total += n;
             #[allow(clippy::indexing_slicing)] // length checked

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -41,7 +41,7 @@ impl SshId {
 
     pub(crate) fn write(&self, buffer: &mut CryptoVec) {
         match self {
-            Self::Standard(s) => buffer.extend(format!("{}\r\n", s).as_bytes()),
+            Self::Standard(s) => buffer.extend(format!("{s}\r\n").as_bytes()),
             Self::Raw(s) => buffer.extend(s.as_bytes()),
         }
     }

--- a/russh/src/tests.rs
+++ b/russh/src/tests.rs
@@ -70,7 +70,7 @@ mod compress {
             ChannelMsg::Data { data: msg_data } => {
                 assert_eq!(*data, *msg_data)
             }
-            msg => panic!("Unexpected message {:?}", msg),
+            msg => panic!("Unexpected message {msg:?}"),
         }
     }
 
@@ -287,7 +287,7 @@ mod channels {
                 if let ChannelMsg::Data { data } = msg {
                     assert_eq!(data.as_ref(), &b"hey there!"[..]);
                 } else {
-                    panic!("Unexpected message {:?}", msg);
+                    panic!("Unexpected message {msg:?}");
                 }
                 s
             },
@@ -342,7 +342,7 @@ mod channels {
                 _session: &mut server::Session,
             ) -> Result<bool, Self::Error> {
                 if let Some(a) = self.channel.take() {
-                    println!("channel open session {:?}", a);
+                    println!("channel open session {a:?}");
                     a.send(channel).unwrap();
                 }
                 Ok(true)
@@ -453,7 +453,7 @@ mod channels {
                 if let ChannelMsg::Data { data } = msg {
                     assert_eq!(data.as_ref(), &b"hello world!"[..]);
                 } else {
-                    panic!("Unexpected message {:?}", msg);
+                    panic!("Unexpected message {msg:?}");
                 }
 
                 assert!(ch.wait().await.is_none());
@@ -511,7 +511,7 @@ mod channels {
                 _session: &mut server::Session,
             ) -> Result<bool, Self::Error> {
                 if let Some(a) = self.channel.take() {
-                    println!("channel open session {:?}", a);
+                    println!("channel open session {a:?}");
                     a.send(channel).unwrap();
                 }
                 Ok(true)
@@ -554,7 +554,7 @@ mod channels {
                                 break;
                             }
                         }
-                        _ => panic!("Unexpected message {:?}", msg),
+                        _ => panic!("Unexpected message {msg:?}"),
                     }
                 }
 

--- a/russh/tests/test_backpressure.rs
+++ b/russh/tests/test_backpressure.rs
@@ -137,7 +137,7 @@ impl russh::server::Handler for Server {
             while let Ok(_) = rx.changed().await {
                 match channel.wait().await {
                     Some(ChannelMsg::Data { .. }) => (),
-                    other => panic!("unexpected message {:?}", other),
+                    other => panic!("unexpected message {other:?}"),
                 }
             }
         });

--- a/russh/tests/test_mlkem_kex.rs
+++ b/russh/tests/test_mlkem_kex.rs
@@ -75,7 +75,7 @@ async fn test_mlkem768x25519_handshake() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"test data with mlkem");
         }
-        msg => panic!("Unexpected message: {:?}", msg),
+        msg => panic!("Unexpected message: {msg:?}"),
     }
 
     channel.eof().await.unwrap();
@@ -150,7 +150,7 @@ async fn test_mlkem768x25519_with_fallback() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"test with fallback");
         }
-        msg => panic!("Unexpected message: {:?}", msg),
+        msg => panic!("Unexpected message: {msg:?}"),
     }
 
     channel.eof().await.unwrap();
@@ -222,7 +222,7 @@ async fn test_mlkem768x25519_rekey() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"before rekey");
         }
-        msg => panic!("Unexpected message before rekey: {:?}", msg),
+        msg => panic!("Unexpected message before rekey: {msg:?}"),
     }
 
     session.rekey_soon().await.unwrap();
@@ -235,7 +235,7 @@ async fn test_mlkem768x25519_rekey() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"after rekey");
         }
-        msg => panic!("Unexpected message after rekey: {:?}", msg),
+        msg => panic!("Unexpected message after rekey: {msg:?}"),
     }
 
     channel.eof().await.unwrap();
@@ -310,7 +310,7 @@ async fn test_mlkem768x25519_multiple_channels() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"channel 1 data");
         }
-        msg => panic!("Unexpected message on channel 1: {:?}", msg),
+        msg => panic!("Unexpected message on channel 1: {msg:?}"),
     }
 
     let msg2 = channel2.wait().await.unwrap();
@@ -318,7 +318,7 @@ async fn test_mlkem768x25519_multiple_channels() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"channel 2 data");
         }
-        msg => panic!("Unexpected message on channel 2: {:?}", msg),
+        msg => panic!("Unexpected message on channel 2: {msg:?}"),
     }
 
     channel1.eof().await.unwrap();

--- a/russh/tests/test_rekey_strict_kex.rs
+++ b/russh/tests/test_rekey_strict_kex.rs
@@ -83,7 +83,7 @@ async fn test_rekey_with_strict_kex() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"before rekey");
         }
-        msg => panic!("Unexpected message before rekey: {:?}", msg),
+        msg => panic!("Unexpected message before rekey: {msg:?}"),
     }
 
     session.rekey_soon().await.unwrap();
@@ -100,7 +100,7 @@ async fn test_rekey_with_strict_kex() {
         ChannelMsg::Data { data } => {
             assert_eq!(&*data, b"after rekey");
         }
-        msg => panic!("Unexpected message after rekey: {:?}", msg),
+        msg => panic!("Unexpected message after rekey: {msg:?}"),
     }
 
     // Close the channel


### PR DESCRIPTION
This PR contains 2 changes:
* The results of `cargo clippy --fix`
* Manual additions of `#[allow(clippy::large_enum_variant)]`, since boxing those variants would break russh's public interface, I opted to just allow the lint instead. Happy to raise a ticket to investigate boxing the variants if thats something you care about.