### PR TITLE
Error on unsupported authentication method instead of panicking

### DIFF
--- a/russh/src/lib_inner.rs
+++ b/russh/src/lib_inner.rs
@@ -121,6 +121,10 @@ pub enum Error {
     #[error("Not yet authenticated")]
     NotAuthenticated,
 
+    /// The client has presented an unsupported authentication method.
+    #[error("Unsupported authentication method")]
+    UnsupportedAuthMethod,
+
     /// Index out of bounds.
     #[error("Index out of bounds")]
     IndexOutOfBounds,

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -575,7 +575,7 @@ async fn reply_userauth_info_response(
             })?;
             Ok(false)
         }
-        Auth::UnsupportedMethod => unreachable!(),
+        Auth::UnsupportedMethod => Err(Error::UnsupportedAuthMethod),
     }
 }
 


### PR DESCRIPTION
This is a minor issue, but I've discovered that a russh server panics when presented with RFC-compliant clients. You can see the discussion of a similar issue [here](http://lists.mindrot.org/pipermail/openssh-unix-dev/2015-April/033789.html) but the TL;DR is that clients are allowed to send all zero auth requests which is allowed according to RFC4256:

> The num-prompts field may be `0', in which case there will be no
   prompt/echo fields in the message, but the client SHOULD still
   display the name and instruction fields (as described below).

I've proposed my solution in the PR, but let me know if you'd prefer the auth outright rejected instead of an error thrown.

Thank you!