### PR TITLE
allow creation of RunningServer from the application

### DIFF
--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -48,13 +48,13 @@ use tokio::net::{TcpListener, ToSocketAddrs};
 use tokio::pin;
 use tokio::sync::{broadcast, mpsc};
 
-use crate::cipher::{clear, OpeningKey};
-use crate::kex::dh::groups::{DhGroup, BUILTIN_SAFE_DH_GROUPS, DH_GROUP14};
+use crate::cipher::{OpeningKey, clear};
+use crate::kex::dh::groups::{BUILTIN_SAFE_DH_GROUPS, DH_GROUP14, DhGroup};
 use crate::kex::{KexProgress, SessionKexState};
 use crate::session::*;
 use crate::ssh_read::*;
 use crate::sshbuffer::*;
-use crate::{*};
+use crate::*;
 
 mod kex;
 mod session;
@@ -813,6 +813,10 @@ pub struct RunningServer<F: Future<Output = std::io::Result<()>> + Unpin + Send>
 }
 
 impl<F: Future<Output = std::io::Result<()>> + Unpin + Send> RunningServer<F> {
+    pub fn new(inner: F, shutdown_tx: broadcast::Sender<String>) -> Self {
+        Self { inner, shutdown_tx }
+    }
+
     pub fn handle(&self) -> RunningServerHandle {
         RunningServerHandle {
             shutdown_tx: self.shutdown_tx.clone(),


### PR DESCRIPTION
Sometimes it’s useful to re-implement `run_on_socket` with custom logic - for example, to read a PROXY protocol header before fully establishing the connection. To support this, we need a way to construct a `RunningServer` directly.

This PR introduces a new constructor for `RunningServer`, allowing callers to create instances manually and plug in their own connection handling logic.