### PR TITLE
fix: upgrade libcrux-ml-kem since 0.0.3 was yanked

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -53,7 +53,7 @@ getrandom = { version = "0.2.15", features = ["js"] }
 hex-literal = "0.4"
 hmac.workspace = true
 inout = { version = "0.1", features = ["std"] }
-libcrux-ml-kem = { version = "0.0.3" }
+libcrux-ml-kem = { version = "0.0.4" }
 log.workspace = true
 md5 = "0.7"
 num-bigint = { version = "0.4.2", features = ["rand"] }


### PR DESCRIPTION
Version [0.0.3 of libcrux-ml-kem](https://crates.io/crates/libcrux-ml-kem/0.0.3) which prevents deps resolution. This PR upgrades it to `0.0.4`.