### PR TITLE
Update libcrux-ml-kem to 0.0.4

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -53,7 +53,7 @@ getrandom = { version = "0.2.15", features = ["js"] }
 hex-literal = "0.4"
 hmac.workspace = true
 inout = { version = "0.1", features = ["std"] }
-libcrux-ml-kem = { version = "0.0.3" }
+libcrux-ml-kem = { version = "0.0.4" }
 log.workspace = true
 md5 = "0.7"
 num-bigint = { version = "0.4.2", features = ["rand"] }


### PR DESCRIPTION
The previous version was yanked because it gave incorrect results on aarch64 platforms. This caused interoperability problems between amd64 and aarch64 platforms.

For information, see:
https://github.com/cryspen/libcrux/issues/1220

Fixes #599