### PR TITLE
Add server side ping

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -1045,6 +1045,9 @@ impl Session {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
                     }
+                    Some(GlobalRequestResponse::Ping(return_channel)) => {
+                        let _ = return_channel.send(());
+                    }
                     Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
                         let result = if r.is_finished() {
                             // If a specific port was requested, the reply has no data
@@ -1074,6 +1077,9 @@ impl Session {
                 match self.open_global_requests.pop_front() {
                     Some(GlobalRequestResponse::Keepalive) => {
                         // ignore keepalives
+                    }
+                    Some(GlobalRequestResponse::Ping(return_channel)) => {
+                        let _ = return_channel.send(());
                     }
                     Some(GlobalRequestResponse::TcpIpForward(return_channel)) => {
                         let _ = return_channel.send(None);

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -975,6 +975,21 @@ impl Session {
         Ok(())
     }
 
+    /// Ping the client with a Keepalive and get a notification when the client responds.
+    pub fn send_ping(&mut self, reply_channel: oneshot::Sender<()>) -> Result<(), Error> {
+        let want_reply = u8::from(true);
+        if let Some(ref mut enc) = self.common.encrypted {
+            self.open_global_requests
+                .push_back(GlobalRequestResponse::Ping(reply_channel));
+            push_packet!(enc.write, {
+                msg::GLOBAL_REQUEST.encode(&mut enc.write)?;
+                "keepalive@openssh.com".encode(&mut enc.write)?;
+                want_reply.encode(&mut enc.write)?;
+            })
+        }
+        Ok(())
+    }
+
     /// Send the exit status of a program.
     pub fn exit_status_request(
         &mut self,


### PR DESCRIPTION
Similar to the client, add a `send_ping` function to the server session. This re-uses the `keepalive@openssh.com` global request, but gives a tokio channel to send back to when the server receives a response.

It can be used like so:

```rs
let (tx, rx) = tokio::sync::oneshot::channel();
let now = std::time::Instant::now();
session.send_ping(tx).unwrap();
tokio::task::spawn(async move {
    rx.await.unwrap();
    let took = std::time::Instant::now() - now;
    tracing::info!(took=?took, "ping");
});
```

I then artificially added 100ms ping to localhost (each direction):

```
sudo tc qdisc add dev lo root netem delay 100ms
```

Then I connect to the local ssh server and see logs like:

```
ping took=200.734513ms
ping took=200.458655ms
ping took=200.801369ms
ping took=200.508387ms
ping took=200.680368ms
```

Related issue: #417

My use case for this is an SSH app where I want to display the current approximate ping of the client in the TUI.

Also of note implementation-wise is that the openssh client appears to always reply to these requests with `REQUEST_FAILURE`, but I added the response handling to `REQUEST_SUCCESS` as well anyways, just in case.