### PR TITLE
Make Config accessor methods for user/port/host public

### DIFF
--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -148,7 +148,7 @@ impl Config {
         }
     }
 
-    fn user(&self) -> String {
+    pub fn user(&self) -> String {
         self.user
             .as_deref()
             .or(self.host_config.user.as_deref())
@@ -156,11 +156,11 @@ impl Config {
             .unwrap_or_else(whoami::username)
     }
 
-    fn port(&self) -> u16 {
+    pub fn port(&self) -> u16 {
         self.host_config.port.or(self.port).unwrap_or(22)
     }
 
-    fn host(&self) -> &str {
+    pub fn host(&self) -> &str {
         self.host_config
             .hostname
             .as_ref()


### PR DESCRIPTION
russh_config::Config struct has gone private. But it's not unreasonable for client apps using parse_home() and friends to want to inspect the results of the excellent ssh_config parsing code, eg. host1 maps to user foo@bar:2022 etc etc., so they can print progress/diagnostic messages. There are some helpful accessor functions for user/port/host, but they are not public, so this PR simply marks those methods public. 