### PR TITLE
Pageant WM_COPYDATA protocol fix & token tightening

### DIFF
--- a/pageant/src/wmmessage.rs
+++ b/pageant/src/wmmessage.rs
@@ -233,24 +233,15 @@ pub fn query_pageant_direct(cookie: String, msg: &[u8]) -> Result<Vec<u8>, Error
     let hwnd = find_pageant_window()?;
     let map_name = format!("PageantRequest{cookie}");
 
-    let user = get_current_process_user()?;
-
-    let mut sd = SECURITY_DESCRIPTOR::default();
-    let psd = PSECURITY_DESCRIPTOR(&mut sd as *mut _ as *mut _);
-
-    unsafe {
-        InitializeSecurityDescriptor(psd, 1)?;
-        SetSecurityDescriptorOwner(psd, Some(user.User.Sid), false)?;
-    }
-
     let mut map: MemoryMap = MemoryMap::new(map_name.clone(), _AGENT_MAX_MSGLEN, None)?;
     map.write(msg)?;
 
     let char_buffer = CString::new(map_name.as_bytes()).map_err(|_| Error::InvalidCookie)?;
+    let char_buffer_bytes = char_buffer.as_bytes_with_nul();
     let cds = COPYDATASTRUCT {
         dwData: _AGENT_COPYDATA_ID as usize,
-        cbData: char_buffer.as_bytes().len() as u32 + 1,
-        lpData: char_buffer.as_bytes().as_ptr() as *mut _,
+        cbData: char_buffer_bytes.len() as u32,
+        lpData: char_buffer_bytes.as_ptr() as *mut _,
     };
 
     let response = unsafe {

--- a/pageant/src/wmmessage.rs
+++ b/pageant/src/wmmessage.rs
@@ -9,16 +9,11 @@ use delegate::delegate;
 use log::debug;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, DuplexStream, ReadBuf};
 use windows::Win32::Foundation::{CloseHandle, HANDLE, HWND, INVALID_HANDLE_VALUE, LPARAM, WPARAM};
-use windows::Win32::Security::{
-    GetTokenInformation, InitializeSecurityDescriptor, PSECURITY_DESCRIPTOR, SECURITY_ATTRIBUTES,
-    SECURITY_DESCRIPTOR, SetSecurityDescriptorOwner, TOKEN_QUERY, TOKEN_USER, TokenUser,
-};
 use windows::Win32::System::DataExchange::COPYDATASTRUCT;
 use windows::Win32::System::Memory::{
     CreateFileMappingW, FILE_MAP_WRITE, MEMORY_MAPPED_VIEW_ADDRESS, MapViewOfFile, PAGE_READWRITE,
     UnmapViewOfFile,
 };
-use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 use windows::Win32::UI::WindowsAndMessaging::{FindWindowW, SendMessageA, WM_COPYDATA};
 use windows::core::HSTRING;
 
@@ -112,15 +107,13 @@ struct MemoryMap {
 }
 
 impl MemoryMap {
-    fn new(
-        name: String,
-        length: usize,
-        security_attributes: Option<SECURITY_ATTRIBUTES>,
-    ) -> Result<Self, Error> {
+    fn new(name: String, length: usize) -> Result<Self, Error> {
         let filemap = unsafe {
             CreateFileMappingW(
                 INVALID_HANDLE_VALUE,
-                security_attributes.map(|sa| &sa as *const _),
+                // Default security descriptor from the process token: owned by the
+                // current user, which is what Pageant's owner check expects
+                None,
                 PAGE_READWRITE,
                 0,
                 length as u32,
@@ -202,38 +195,12 @@ pub fn is_pageant_running() -> bool {
     find_pageant_window().is_ok()
 }
 
-fn get_current_process_user() -> Result<TOKEN_USER, Error> {
-    unsafe {
-        let mut process_token = HANDLE::default();
-        OpenProcessToken(
-            GetCurrentProcess(),
-            TOKEN_QUERY,
-            &mut process_token as *mut _,
-        )?;
-
-        let mut info_size = 0;
-        let _ = GetTokenInformation(process_token, TokenUser, None, 0, &mut info_size);
-
-        let mut buffer = vec![0; info_size as usize];
-        GetTokenInformation(
-            process_token,
-            TokenUser,
-            Some(buffer.as_mut_ptr() as *mut _),
-            buffer.len() as u32,
-            &mut info_size,
-        )?;
-        let user: TOKEN_USER = *(buffer.as_ptr() as *const _);
-        let _ = CloseHandle(process_token);
-        Ok(user)
-    }
-}
-
 /// Send a one-off query to Pageant and return a response.
 pub fn query_pageant_direct(cookie: String, msg: &[u8]) -> Result<Vec<u8>, Error> {
     let hwnd = find_pageant_window()?;
     let map_name = format!("PageantRequest{cookie}");
 
-    let mut map: MemoryMap = MemoryMap::new(map_name.clone(), _AGENT_MAX_MSGLEN, None)?;
+    let mut map: MemoryMap = MemoryMap::new(map_name.clone(), _AGENT_MAX_MSGLEN)?;
     map.write(msg)?;
 
     let char_buffer = CString::new(map_name.as_bytes()).map_err(|_| Error::InvalidCookie)?;


### PR DESCRIPTION
1. pageant MemoryMap always fail in cargo build --release mode if pass the security_attributes argument in MemoryMap::new, I don't know why, but pass None can fix it.
2. Support ssh certificate based authentication, when use sshagent, it will scan for both cert and publickey, if is cert, it should trigger the new auth method. example is here [https://github.com/vzex/russh/blob/main/russh/examples/client_exec_sshagent.rs](https://github.com/vzex/russh/blob/main/russh/examples/client_exec_sshagent.rs)
