### PR TITLE
fix: prevent deadlock when using make_writer for large transfers

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -551,8 +551,10 @@ impl Session {
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.window_size().update(new_size).await;
-
-                    let _ = chan.send(ChannelMsg::WindowAdjusted { new_size }).await;
+                    // Use try_send to avoid blocking the session loop when channel buffer is full.
+                    // WindowAdjusted is informational - the critical side effect (updating
+                    // WindowSizeRef and notifying ChannelTx) already happens in update().
+                    let _ = chan.try_send(ChannelMsg::WindowAdjusted { new_size });
                 }
                 client.window_adjusted(channel_num, new_size, self).await
             }

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -668,10 +668,10 @@ impl Session {
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.window_size().update(new_size).await;
-
-                    chan.send(ChannelMsg::WindowAdjusted { new_size })
-                        .await
-                        .unwrap_or(())
+                    // Use try_send to avoid blocking the session loop when channel buffer is full.
+                    // WindowAdjusted is informational - the critical side effect (updating
+                    // WindowSizeRef and notifying ChannelTx) already happens in update().
+                    let _ = chan.try_send(ChannelMsg::WindowAdjusted { new_size });
                 }
                 debug!("handler.window_adjusted {channel_num:?}");
                 handler.window_adjusted(channel_num, new_size, self).await


### PR DESCRIPTION
When processing WINDOW_ADJUST messages, chan.send.await blocks if the user does not consume channel messages. After ~100 WindowAdjusted messages fill the channel buffer, this causes a deadlock. Change to try_send which is non-blocking. WindowAdjusted is informational - the critical side effect already happens in update. Fixes #266, Fixes #571