### PR TITLE
fix(deps): bump rand libraries to 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ futures = "0.3"
 home = "0.5"
 hmac = "0.12"
 log = "0.4.11"
-rand = { version = "0.9", features = ["thread_rng"] }
+rand = { version = "0.10", features = ["thread_rng"] }
 sha1 = { version = "0.10.5", features = ["oid"] }
 sha2 = { version = "0.10.6", features = ["oid"] }
 signature = "2.2"

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -65,7 +65,7 @@ pbkdf2 = "0.12"
 pkcs1 = { version = "0.8.0-rc.4", optional = true }
 pkcs5 = "0.7"
 pkcs8 = { version = "0.10", features = ["pkcs5", "encryption", "std"] }
-rand_core = { version = "=0.10.0-rc-3" }
+rand_core = { version = "0.10" }
 rand.workspace = true
 ring = { version = "0.17.14", optional = true }
 rsa = { version = "0.10.0-rc.10", optional = true }

--- a/russh/src/cipher/block.rs
+++ b/russh/src/cipher/block.rs
@@ -17,7 +17,7 @@ use std::marker::PhantomData;
 use aes::cipher::{IvSizeUser, KeyIvInit, KeySizeUser, StreamCipher};
 #[allow(deprecated)]
 use digest::generic_array::GenericArray as GenericArray_0_14;
-use rand::RngCore;
+use rand_core::Rng;
 
 use super::super::Error;
 use super::PACKET_LENGTH_LEN;

--- a/russh/src/cipher/gcm.rs
+++ b/russh/src/cipher/gcm.rs
@@ -25,7 +25,7 @@ use aws_lc_rs::{
     },
     error::Unspecified,
 };
-use rand::RngCore;
+use rand_core::Rng;
 #[cfg(all(not(feature = "aws-lc-rs"), feature = "ring"))]
 use ring::{
     aead::{

--- a/russh/src/keys/format/pkcs8.rs
+++ b/russh/src/keys/format/pkcs8.rs
@@ -118,7 +118,7 @@ pub fn encode_pkcs8_encrypted(
     let pvi_bytes = encode_pkcs8(key)?;
     let pvi = PrivateKeyInfo::try_from(pvi_bytes.as_slice())?;
 
-    use rand::RngCore;
+    use rand_core::Rng;
     let mut rng = safe_rng();
     let mut salt = [0; 64];
     rng.fill_bytes(&mut salt);

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -15,7 +15,7 @@
 use std::borrow::Cow;
 
 use log::debug;
-use rand::RngCore;
+use rand_core::Rng;
 use ssh_encoding::{Decode, Encode};
 use ssh_key::{Algorithm, EcdsaCurve, HashAlg, PrivateKey};
 


### PR DESCRIPTION
Version `0.10` is out and the exact pin is making it difficult to align the versions in a dependency tree.