### PR TITLE
Fix zlib vs zlib@openssh.com compression timing (#564)

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -109,7 +109,9 @@ impl Session {
                                 .send(Reply::AuthSuccess)
                                 .map_err(|_| crate::Error::SendError)?;
                             enc.state = EncryptedState::InitCompression;
-                            enc.server_compression.init_decompress(&mut enc.decompress);
+                            if enc.server_compression.is_deferred() {
+                                enc.server_compression.init_decompress(&mut enc.decompress);
+                            }
                             return Ok(());
                         }
                         Some((&msg::USERAUTH_BANNER, mut r)) => {

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -1188,8 +1188,10 @@ impl Session {
 
             if let Some(ref mut enc) = self.common.encrypted {
                 if let EncryptedState::InitCompression = enc.state {
-                    enc.client_compression
-                        .init_compress(self.common.packet_writer.compress());
+                    if enc.client_compression.is_deferred() {
+                        enc.client_compression
+                            .init_compress(self.common.packet_writer.compress());
+                    }
                     enc.state = EncryptedState::Authenticated;
                 }
             }

--- a/russh/src/compression.rs
+++ b/russh/src/compression.rs
@@ -8,6 +8,8 @@ pub enum Compression {
     None,
     #[cfg(feature = "flate2")]
     Zlib,
+    #[cfg(feature = "flate2")]
+    ZlibOpenSSH,
 }
 
 #[derive(Debug)]
@@ -67,34 +69,55 @@ pub const ALL_COMPRESSION_ALGORITHMS: &[&Name] = &[
 #[cfg(feature = "flate2")]
 impl Compression {
     pub fn new(name: &Name) -> Self {
-        if name == &ZLIB || name == &ZLIB_LEGACY {
+        if name == &ZLIB {
             Compression::Zlib
+        } else if name == &ZLIB_LEGACY {
+            Compression::ZlibOpenSSH
         } else {
             Compression::None
         }
     }
 
     pub fn init_compress(&self, comp: &mut Compress) {
-        if let Compression::Zlib = *self {
-            if let Compress::Zlib(ref mut c) = *comp {
-                c.reset()
-            } else {
-                *comp = Compress::Zlib(flate2::Compress::new(flate2::Compression::fast(), true))
+        match *self {
+            Compression::Zlib | Compression::ZlibOpenSSH => {
+                if let Compress::Zlib(ref mut c) = *comp {
+                    c.reset()
+                } else {
+                    *comp =
+                        Compress::Zlib(flate2::Compress::new(flate2::Compression::fast(), true))
+                }
             }
-        } else {
-            *comp = Compress::None
+            Compression::None => {
+                *comp = Compress::None;
+            }
         }
     }
 
     pub fn init_decompress(&self, comp: &mut Decompress) {
-        if let Compression::Zlib = *self {
-            if let Decompress::Zlib(ref mut c) = *comp {
-                c.reset(true)
-            } else {
-                *comp = Decompress::Zlib(flate2::Decompress::new(true))
+        match *self {
+            Compression::Zlib | Compression::ZlibOpenSSH => {
+                if let Decompress::Zlib(ref mut c) = *comp {
+                    c.reset(true)
+                } else {
+                    *comp = Decompress::Zlib(flate2::Decompress::new(true))
+                }
             }
-        } else {
-            *comp = Decompress::None
+            Compression::None => {
+                *comp = Decompress::None;
+            }
+        }
+    }
+}
+
+impl Compression {
+    /// Returns true if compression should be deferred until after authentication.
+    /// "zlib@openssh.com" defers; RFC 4253 "zlib" does not.
+    pub fn is_deferred(&self) -> bool {
+        match self {
+            #[cfg(feature = "flate2")]
+            Compression::ZlibOpenSSH => true,
+            _ => false,
         }
     }
 }

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -97,7 +97,9 @@ impl Session {
                 .await?;
                 self.common.auth_attempts += 1;
                 if let EncryptedState::InitCompression = enc.state {
-                    enc.client_compression.init_decompress(&mut enc.decompress);
+                    if enc.client_compression.is_deferred() {
+                        enc.client_compression.init_decompress(&mut enc.decompress);
+                    }
                     handler.auth_succeeded(self).await?;
                 }
                 Ok(())
@@ -117,15 +119,19 @@ impl Session {
                 .await?;
                 if resp {
                     enc.state = EncryptedState::InitCompression;
-                    enc.client_compression.init_decompress(&mut enc.decompress);
+                    if enc.client_compression.is_deferred() {
+                        enc.client_compression.init_decompress(&mut enc.decompress);
+                    }
                     handler.auth_succeeded(self).await
                 } else {
                     Ok(())
                 }
             }
             (EncryptedState::InitCompression, Some((msg, mut r))) => {
-                enc.server_compression
-                    .init_compress(self.common.packet_writer.compress());
+                if enc.server_compression.is_deferred() {
+                    enc.server_compression
+                        .init_compress(self.common.packet_writer.compress());
+                }
                 enc.state = EncryptedState::Authenticated;
                 self.server_read_authenticated(handler, *msg, &mut r).await
             }

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -166,6 +166,20 @@ impl<C> CommonSession<C> {
         self.packet_writer
             .set_cipher(newkeys.cipher.local_to_remote);
         self.strict_kex = strict_kex;
+
+        // For non-deferred compression (RFC 4253 "zlib"), activate immediately
+        // after initial key exchange. Deferred compression ("zlib@openssh.com")
+        // will be activated later, after authentication succeeds.
+        if let Some(ref mut enc) = self.encrypted {
+            if !enc.client_compression.is_deferred() {
+                enc.client_compression
+                    .init_compress(self.packet_writer.compress());
+            }
+            if !enc.server_compression.is_deferred() {
+                enc.server_compression
+                    .init_decompress(&mut enc.decompress);
+            }
+        }
     }
 
     /// Send a disconnect message.


### PR DESCRIPTION
## Summary

Fixes #564.

The `Compression` enum previously mapped both `zlib` (RFC 4253) and `zlib@openssh.com` to the same `Zlib` variant, losing the critical timing distinction between the two algorithms:

- **`zlib`** (RFC 4253) - compression activates immediately after `SSH_MSG_NEWKEYS` (initial key exchange)
- **`zlib@openssh.com`** - compression is deferred until after user authentication succeeds

Because both were treated identically, russh only activated compression after authentication, which broke interoperability with clients/servers that negotiate plain `zlib` and expect compression to start right after key exchange. This was originally reported by Simon Tatham (PuTTY maintainer).

## What this fix does

- Adds a new `Compression::ZlibOpenSSH` variant to distinguish `zlib@openssh.com` from plain `zlib`
- Adds an `is_deferred()` method that returns `true` only for `ZlibOpenSSH`
- Guards all post-authentication compression activation points with `is_deferred()` checks, so they only fire for the deferred variant
- Activates non-deferred (`zlib`) compression immediately in `newkeys_received()`, right after key exchange completes

### Files changed

- `russh/src/compression.rs` - new `ZlibOpenSSH` variant, updated `new()` constructor, `is_deferred()` method
- `russh/src/session.rs` - activate non-deferred compression at key exchange time
- `russh/src/client/encrypted.rs` - guard deferred decompression init with `is_deferred()`
- `russh/src/client/mod.rs` - guard deferred compression init with `is_deferred()`
- `russh/src/server/encrypted.rs` - guard deferred compress/decompress init with `is_deferred()`

## Test plan

- All existing tests pass, including the compression integration test (`cargo test`)
- The fix is a minimal, targeted change that preserves existing `zlib@openssh.com` behavior while correctly adding the RFC 4253 `zlib` immediate-activation path