### PR TITLE
chore: bump thiserror to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,6 @@ ssh-key = { version = "=0.6.16", features = [
     "ppk",
     "hazmat-allow-insecure-rsa-keys",
 ], package = "internal-russh-forked-ssh-key" }
-thiserror = "1.0.30"
+thiserror = "2.0.18"
 tokio = { version = "1.17.0" }
 tokio-stream = { version = "0.1.3", features = ["net", "sync"] }


### PR DESCRIPTION
Update the `thiserror` crate to the newest release.