### PR TITLE
Add russh/serde feature to enable serde on russh::keys::PublicKey

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -24,6 +24,7 @@ des = ["dep:des"]
 dsa = ["ssh-key/dsa"]
 ring = ["dep:ring"] # Alternative crypto backend.
 rsa = ["dep:rsa", "dep:pkcs1", "ssh-key/rsa", "ssh-key/rsa-sha1"]
+serde = ["ssh-key/serde"]
 _bench = ["dep:criterion"]
 
 [dependencies]


### PR DESCRIPTION
This way I don't need to add a dependency on `internal-russh-forked-ssh-key` to enable the `serde` feature (and keep the version constrain in-sync) and instead can just do it through `russh` :)