### PR TITLE
fix: use remote channel ID in CHANNEL_REQUEST replies

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -508,10 +508,12 @@ impl Session {
                             if let Some(ref mut enc) = self.common.encrypted {
                                 trace!("Received channel keep alive message: {req:?}",);
                                 self.common.wants_reply = false;
-                                push_packet!(enc.write, {
-                                    map_err!(msg::CHANNEL_SUCCESS.encode(&mut enc.write))?;
-                                    map_err!(channel_num.encode(&mut enc.write))?;
-                                });
+                                if let Some(ch) = enc.channels.get(&channel_num) {
+                                    push_packet!(enc.write, {
+                                        map_err!(msg::CHANNEL_SUCCESS.encode(&mut enc.write))?;
+                                        map_err!(ch.recipient_channel.encode(&mut enc.write))?;
+                                    });
+                                }
                             }
                         } else {
                             warn!("Received keepalive without reply request!");
@@ -523,10 +525,12 @@ impl Session {
                         if wants_reply == 1 {
                             if let Some(ref mut enc) = self.common.encrypted {
                                 self.common.wants_reply = false;
-                                push_packet!(enc.write, {
-                                    map_err!(msg::CHANNEL_FAILURE.encode(&mut enc.write))?;
-                                    map_err!(channel_num.encode(&mut enc.write))?;
-                                })
+                                if let Some(ch) = enc.channels.get(&channel_num) {
+                                    push_packet!(enc.write, {
+                                        map_err!(msg::CHANNEL_FAILURE.encode(&mut enc.write))?;
+                                        map_err!(ch.recipient_channel.encode(&mut enc.write))?;
+                                    })
+                                }
                             }
                         }
                         info!("Unknown channel request {req:?} {wants_reply:?}",);


### PR DESCRIPTION
Fixes #567 

CHANNEL_SUCCESS and CHANNEL_FAILURE replies to incoming CHANNEL_REQUEST messages wrote the local (client-side) channel ID instead of the remote (server-side) channel ID.

Per RFC 4254 §5.4, the "recipient channel" field must contain the channel number assigned by the sender of the original request, i.e. the server-side ID stored in `ChannelParams::recipient_channel`.

When multiple channels exist and the local and remote IDs diverge, the server cannot match the reply to any known channel. Servers with keepalive enabled (e.g. OpenSSH ClientAliveInterval) interpret this as an unresponsive client and disconnect after ClientAliveCountMax failed attempts.