### PR TITLE
Remove Home Crate Dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ digest = "0.10"
 delegate = "0.13"
 env_logger = "0.6"
 futures = "0.3"
-home = "0.5"
 hmac = "0.12"
 log = "0.4.11"
 rand = { version = "0.9", features = ["thread_rng"] }

--- a/russh-config/Cargo.toml
+++ b/russh-config/Cargo.toml
@@ -11,7 +11,6 @@ version = "0.57.0"
 rust-version = "1.85"
 
 [dependencies]
-home.workspace = true
 futures.workspace = true
 globset = "0.4"
 log.workspace = true

--- a/russh-config/src/lib.rs
+++ b/russh-config/src/lib.rs
@@ -4,6 +4,7 @@
     clippy::indexing_slicing,
     clippy::panic
 )]
+use std::env;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
@@ -320,7 +321,7 @@ pub fn parse(file: &str, host: &str) -> Result<Config, Error> {
 }
 
 pub fn parse_home(host: &str) -> Result<Config, Error> {
-    let mut home = if let Some(home) = home::home_dir() {
+    let mut home = if let Some(home) = env::home_dir() {
         home
     } else {
         return Err(Error::NoHome);
@@ -373,7 +374,7 @@ impl SshConfigStrExt for &str {
 
     fn expand_home(&self) -> Result<PathBuf, Error> {
         if self.starts_with("~/") {
-            if let Some(mut home) = home::home_dir() {
+            if let Some(mut home) = env::home_dir() {
                 home.push(self.split_at(2).1);
                 Ok(home)
             } else {
@@ -388,6 +389,7 @@ impl SshConfigStrExt for &str {
 #[cfg(test)]
 mod tests {
     #![allow(clippy::expect_used)]
+    use std::env;
     use std::path::{Path, PathBuf};
 
     use crate::{AddKeysToAgent, Config, Error, SshConfigStrExt, parse};
@@ -420,7 +422,7 @@ mod tests {
         assert_eq!(
             format!(
                 "{}{}",
-                home::home_dir().expect("homedir").to_str().expect("to_str"),
+                env::home_dir().expect("homedir").to_str().expect("to_str"),
                 "/some/folder"
             ),
             value.to_str().unwrap()
@@ -455,7 +457,7 @@ Host test_host
 #";
         let identity_file = PathBuf::from(format!(
             "{}{}",
-            home::home_dir().expect("homedir").to_str().expect("to_str"),
+            env::home_dir().expect("homedir").to_str().expect("to_str"),
             "/.ssh/id_ed25519"
         ));
         let config = parse(value, "test_host").expect("parse");

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -98,7 +98,6 @@ tokio = { workspace = true, features = [
   "time",
   "net",
 ] }
-home.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 pageant = { version = "0.2", path = "../pageant" }

--- a/russh/src/keys/known_hosts.rs
+++ b/russh/src/keys/known_hosts.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
+use std::env;
 
 use data_encoding::BASE64_MIME;
 use hmac::{Hmac, Mac};
@@ -48,7 +49,7 @@ pub fn check_known_hosts_path<P: AsRef<Path>>(
 }
 
 fn known_hosts_path() -> Result<PathBuf, Error> {
-    home::home_dir()
+    env::home_dir()
         .map(|home_dir| home_dir.join(".ssh").join("known_hosts"))
         .ok_or(Error::NoHomeDir)
 }


### PR DESCRIPTION
The home crate provides the function home_dir() to work around a bug in std::env::home_dir() on Windows (incorrectly considering the HOME env var). Since Russh uses Rust 1.85, this issue is fixed, making the home crate unnecessary.

See: https://crates.io/crates/home/0.5.12

> Note: This has been fixed in Rust 1.85 to no longer use the HOME environment variable on Windows. If you are still using this crate for the purpose of getting a home directory, you are strongly encouraged to switch to using the standard library's [home_dir](https://doc.rust-lang.org/nightly/std/env/fn.home_dir.html) instead. It is planned to have the deprecation notice removed in 1.87.