### PR TITLE
Reply with CHANNEL_CLOSE in server handler per RFC 4254

### DIFF
--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -600,7 +600,8 @@ impl Session {
             msg::CHANNEL_CLOSE => {
                 let channel_num = map_err!(ChannelId::decode(r))?;
                 if let Some(ref mut enc) = self.common.encrypted {
-                    enc.channels.remove(&channel_num);
+                    // Reply with CHANNEL_CLOSE per RFC 4254 Section 5.3.
+                    enc.close(channel_num)?;
                 }
                 self.channels.remove(&channel_num);
                 debug!("handler.channel_close {channel_num:?}");


### PR DESCRIPTION
## Problem

When the server receives `CHANNEL_CLOSE` from a client, it removes the channel from `enc.channels` but never sends `CHANNEL_CLOSE` back on the wire.

[RFC 4254 Section 5.3](https://www.rfc-editor.org/rfc/rfc4254#section-5.3) requires:

> Upon receiving this message, a party MUST send back an SSH_MSG_CHANNEL_CLOSE unless it has already sent this message for the channel.

The client-side `CHANNEL_CLOSE` handler already does this correctly via `enc.close()`. The server-side handler was calling `enc.channels.remove()` directly, skipping the reply. This also matches [OpenSSH's behavior](https://github.com/openssh/openssh-portable/blob/master/nchan.c), where `chan_rcvd_oclose()` always ensures `CHANNEL_CLOSE` is sent back before freeing the channel.

## Changes

One-line change in `server/encrypted.rs`: replace `enc.channels.remove(&channel_num)` with `enc.close(channel_num)?`, matching the client-side handler. `enc.close()` sends `CHANNEL_CLOSE` on the wire (or defers it if there is pending data) and removes the channel.