### PR TITLE
Update Rust dependencies

### DIFF
--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -14,10 +14,10 @@ ssh-encoding = { workspace = true, optional = true }
 log.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["mman"] }
+nix = { version = "0.31", features = ["mman"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.59", features = [
+windows-sys = { version = "0.61", features = [
     "Win32_System_Memory",
     "Win32_System_SystemInformation",
     "Win32_System_Threading",

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -51,7 +51,7 @@ flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
 generic-array = { version = "1.3.3", features = ["compat-0_14"] }
 getrandom = { version = "0.2.15", features = ["js"] }
-hex-literal = "0.4"
+hex-literal = "1"
 hmac.workspace = true
 inout = { version = "0.1", features = ["std"] }
 log.workspace = true
@@ -121,7 +121,7 @@ rand.workspace = true
 shell-escape = "0.1"
 tokio-fd = "0.3"
 termion = "4"
-ratatui = "0.29.0"
+ratatui = "0.30"
 tempfile = "3.14.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]


### PR DESCRIPTION
Updated only Rust dependencies that require no code changes:

```
  Updated hex-literal v0.4 -> v1
  Updated nix v0.29 -> v0.31
  Updated ratatui v0.29.0 -> v0.30
  Updated windows-sys v0.59 -> v0.61
```

These changes also fix the following cargo audit warnings:
```

  Crate:     paste
  Version:   1.0.15
  Warning:   unmaintained
  Title:     paste - no longer maintained
  Date:      2024-10-07
  ID:        RUSTSEC-2024-0436
  URL:       https://rustsec.org/advisories/RUSTSEC-2024-0436
  Dependency tree:
  paste 1.0.15
  └── ratatui 0.29.0
      └── russh 0.58.0

  Crate:     lru
  Version:   0.12.5
  Warning:   unsound
  Title:     `IterMut` violates Stacked Borrows by invalidating internal
  pointer
  Date:      2026-01-07
  ID:        RUSTSEC-2026-0002
  URL:       https://rustsec.org/advisories/RUSTSEC-2026-0002
  Dependency tree:
  lru 0.12.5
  └── ratatui 0.29.0
      └── russh 0.58.0
```