### PR TITLE
Add method to do OpenSSH  authentication with hash algo specified

### DIFF
--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -208,6 +208,10 @@ pub enum Method {
         key: Arc<PrivateKey>,
         cert: Certificate,
     },
+    OpenSshCertificateWithHashAlg {
+        key: PrivateKeyWithHashAlg,
+        cert: Certificate,
+    },
     FuturePublicKey {
         key: ssh_key::PublicKey,
         hash_alg: Option<HashAlg>,

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -208,7 +208,7 @@ impl Session {
                                         &mut self.common.buffer,
                                     )?
                                 }
-                                Some(auth_method @ auth::Method::OpenSshCertificate { .. }) => {
+                                Some(auth_method @ auth::Method::OpenSshCertificate { .. }) | Some(auth_method @ auth::Method::OpenSshCertificateWithHashAlg { .. })=> {
                                     self.common.buffer.clear();
                                     enc.client_send_signature(
                                         &self.common.auth_user,
@@ -942,7 +942,7 @@ impl Encrypted {
                     key.public_key().to_bytes()?.encode(&mut self.write)?;
                     true
                 }
-                auth::Method::OpenSshCertificate { ref cert, .. } => {
+                auth::Method::OpenSshCertificate { ref cert, .. } | auth::Method::OpenSshCertificateWithHashAlg { ref cert, .. } => {
                     user.as_bytes().encode(&mut self.write)?;
                     "ssh-connection".encode(&mut self.write)?;
                     "publickey".encode(&mut self.write)?;
@@ -1057,6 +1057,20 @@ impl Encrypted {
                 push_packet!(self.write, {
                     #[allow(clippy::indexing_slicing)] // length checked
                     self.write.extend_from_slice(&buffer[i0..]);
+                })
+            }
+            auth::Method::OpenSshCertificateWithHashAlg { key, cert} => {
+                let i0 = self.client_make_to_sign(
+                    user,
+                    &PublicKeyOrCertificate::Certificate(cert.clone()),
+                    buffer,
+                )?;
+
+                sign_with_hash_alg(key, buffer)?.encode(&mut *buffer)?;
+
+                push_packet!(self.write, {
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    self.write.extend(&buffer[i0..]);
                 })
             }
             _ => {}

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -450,6 +450,26 @@ impl<H: Handler> Handle<H> {
         self.wait_recv_reply().await
     }
 
+    /// Same as [`Handle::authenticate_openssh_cert`], but allows specifying a hash algorithm for RSA keys in the certificate. 
+    /// This is necessary for authentication to succeed with some old servers that does not support `rsa-sha2-512`.
+    /// Perform public OpenSSH Certificate-based SSH authentication with a specified hash algorithm for RSA keys
+    pub async fn authenticate_openssh_cert_with_hash_alg<U: Into<String>>(
+        &mut self,
+        user: U,
+        key: PrivateKeyWithHashAlg,
+        cert: Certificate,
+    ) -> Result<AuthResult, crate::Error> {
+        let user = user.into();
+        self.sender
+            .send(Msg::Authenticate {
+                user,
+                method: auth::Method::OpenSshCertificateWithHashAlg { key, cert },
+            })
+            .await
+            .map_err(|_| crate::Error::SendError)?;
+        self.wait_recv_reply().await
+    }
+
     /// Authenticate using a custom method that implements the
     /// [`Signer`][auth::Signer] trait. Currently, this crate only provides an
     /// implementation for an [SSH agent][crate::keys::agent::client::AgentClient].


### PR DESCRIPTION
`authenticate_openssh_cert` currently hardcodes RSA-SHA-512 for RSA private key signing, causing failures against legacy servers that only accept RSA-SHA-1. This PR adds a new method variant that accepts a PublicKeyOrCertificate argument so callers can control the signing algorithm explicitly.


``` rust
// in ssh-key, this will forcly use RSA-SHA-512 to sign
signature::Signer::try_sign(key.deref(), buffer)?
    .encoded()?
    .encode(&mut *buffer)?;
```