### PR TITLE
bumps libcrux-ml-kem to fix RUSTSEC-2026-0074

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -54,7 +54,7 @@ getrandom = { version = "0.2.15", features = ["js"] }
 hex-literal = "0.4"
 hmac.workspace = true
 inout = { version = "0.1", features = ["std"] }
-libcrux-ml-kem = { version = "0.0.4" }
+libcrux-ml-kem = { version = "0.0.8" }
 log.workspace = true
 md5 = "0.7"
 num-bigint = { version = "0.4.2", features = ["rand"] }


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2026-0074.html