### PR TITLE
Bump aws-lc-rs to fix RUSTSEC-2026-0044 and RUSTSEC-2026-0048

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -30,7 +30,7 @@ _bench = ["dep:criterion"]
 [dependencies]
 aes.workspace = true
 async-trait = { workspace = true, optional = true }
-aws-lc-rs = { version = "1.13.1", optional = true }
+aws-lc-rs = { version = "1.16.2", optional = true }
 bitflags = "2.0"
 block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true


### PR DESCRIPTION
Updated aws-lc-rs to address the following cargo audit reports:

	Crate:     aws-lc-sys
	Version:   0.38.0
	Title:     AWS-LC X.509 Name Constraints Bypass via Wildcard/Unicode CN
	Date:      2026-03-19
	ID:        RUSTSEC-2026-0044
	URL:       https://rustsec.org/advisories/RUSTSEC-2026-0044
	Solution:  Upgrade to >=0.39.0
	Dependency tree:
	aws-lc-sys 0.38.0
	└── aws-lc-rs 1.16.1
			└── russh 0.58.0

	Crate:     aws-lc-sys
	Version:   0.38.0
	Title:     CRL Distribution Point Scope Check Logic Error in AWS-LC
	Date:      2026-03-19
	ID:        RUSTSEC-2026-0048
	URL:       https://rustsec.org/advisories/RUSTSEC-2026-0048
	Severity:  7.4 (high)
	Solution:  Upgrade to >=0.39.0