### PR TITLE
fix(negotiation): exclude SHA-1 MACs from Preferred::DEFAULT

### DIFF
--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -131,6 +131,14 @@ const CIPHER_ORDER: &[cipher::Name] = &[
     cipher::AES_128_CTR,
 ];
 
+// SHA-1 MAC variants excluded; see HMAC_ORDER for the full list including legacy algorithms.
+const SAFE_HMAC_ORDER: &[mac::Name] = &[
+    mac::HMAC_SHA512_ETM,
+    mac::HMAC_SHA256_ETM,
+    mac::HMAC_SHA512,
+    mac::HMAC_SHA256,
+];
+
 const HMAC_ORDER: &[mac::Name] = &[
     mac::HMAC_SHA512_ETM,
     mac::HMAC_SHA256_ETM,
@@ -171,7 +179,7 @@ impl Preferred {
             Algorithm::Rsa { hash: None },
         ]),
         cipher: Cow::Borrowed(CIPHER_ORDER),
-        mac: Cow::Borrowed(HMAC_ORDER),
+        mac: Cow::Borrowed(SAFE_HMAC_ORDER),
         compression: Cow::Borrowed(COMPRESSION_ORDER),
     };
 
@@ -179,7 +187,7 @@ impl Preferred {
         kex: Cow::Borrowed(SAFE_KEX_ORDER),
         key: Preferred::DEFAULT.key,
         cipher: Cow::Borrowed(CIPHER_ORDER),
-        mac: Cow::Borrowed(HMAC_ORDER),
+        mac: Cow::Borrowed(SAFE_HMAC_ORDER),
         compression: Cow::Borrowed(COMPRESSION_ORDER),
     };
 }


### PR DESCRIPTION
## Summary

`Preferred::DEFAULT` currently advertises `hmac-sha1-etm@openssh.com` and `hmac-sha1` in its MAC negotiation list via `HMAC_ORDER`. SHA-1 based MACs are deprecated — RFC 8308 recommends against them and OpenSSH 8.7 removed them from its defaults.

The KEX default (`SAFE_KEX_ORDER`) already excludes SHA-1 correctly. This PR brings MAC defaults in line with the same standard.

## Change

Introduce `SAFE_HMAC_ORDER` (SHA-512 and SHA-256 variants only) and use it in `Preferred::DEFAULT` and `Preferred::COMPRESSED`. `HMAC_ORDER` is unchanged and kept available for users who must interoperate with legacy servers:

```rust
// Legacy compatibility — set explicitly if needed
Preferred { mac: Cow::Borrowed(HMAC_ORDER), ..Preferred::DEFAULT }
```

## How to test

```bash
cargo test -p russh
```

Existing tests should pass unchanged. Users explicitly relying on SHA-1 MAC negotiation with legacy servers will need to set `HMAC_ORDER` explicitly — behaviour is otherwise identical for modern servers.

## Notes

Found via static analysis of the published `russh-0.60.0` crate. The `SAFE_KEX_ORDER` naming convention in this codebase gave the approach — felt like the natural parallel for MAC.