### PR TITLE
Fix channel write ordering with pending data

### DIFF
--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -449,7 +449,7 @@ impl Encrypted {
         let buf0 = buf0.into();
         if let Some(channel) = self.channels.get_mut(&channel) {
             assert!(channel.confirmed);
-            if !channel.pending_data.is_empty() && is_rekeying {
+            if !channel.pending_data.is_empty() || is_rekeying {
                 channel.pending_data.push_back((buf0, None, 0));
                 return Ok(());
             }
@@ -473,7 +473,7 @@ impl Encrypted {
         let buf0 = buf0.into();
         if let Some(channel) = self.channels.get_mut(&channel) {
             assert!(channel.confirmed);
-            if !channel.pending_data.is_empty() && is_rekeying {
+            if !channel.pending_data.is_empty() || is_rekeying {
                 channel.pending_data.push_back((buf0, Some(ext), 0));
                 return Ok(());
             }
@@ -835,5 +835,45 @@ mod tests {
             types.iter().filter(|&&t| t == msg::CHANNEL_CLOSE).count(),
             1
         );
+    }
+
+    #[test]
+    fn data_queues_behind_existing_pending_data_when_not_rekeying() {
+        let channel_id = ChannelId(5);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, false, false));
+
+        let initial_pending = encrypted.channels[&channel_id].pending_data.len();
+        encrypted
+            .data(channel_id, Bytes::from_static(b"new"), false)
+            .unwrap();
+
+        assert_eq!(
+            encrypted.channels[&channel_id].pending_data.len(),
+            initial_pending + 1
+        );
+        assert!(encrypted.write.is_empty());
+    }
+
+    #[test]
+    fn extended_data_queues_behind_existing_pending_data_when_not_rekeying() {
+        let channel_id = ChannelId(6);
+        let ext = 1;
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, false, false));
+
+        let initial_pending = encrypted.channels[&channel_id].pending_data.len();
+        encrypted
+            .extended_data(channel_id, ext, Bytes::from_static(b"new"), false)
+            .unwrap();
+
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(channel.pending_data.len(), initial_pending + 1);
+        assert_eq!(channel.pending_data.back().unwrap().1, Some(ext));
+        assert!(encrypted.write.is_empty());
     }
 }

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -845,15 +845,26 @@ mod tests {
             .channels
             .insert(channel_id, test_channel(channel_id, 42, false, false));
 
-        let initial_pending = encrypted.channels[&channel_id].pending_data.len();
+        let channel = &encrypted.channels[&channel_id];
+        let initial_pending = channel.pending_data.len();
+        assert!(initial_pending > 0);
+        let initial_front = channel.pending_data.front().unwrap();
+        let initial_front_data = initial_front.0.to_vec();
+        let initial_front_ext = initial_front.1;
+
         encrypted
             .data(channel_id, Bytes::from_static(b"new"), false)
             .unwrap();
 
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(channel.pending_data.len(), initial_pending + 1);
         assert_eq!(
-            encrypted.channels[&channel_id].pending_data.len(),
-            initial_pending + 1
+            channel.pending_data.front().unwrap().0.as_ref(),
+            initial_front_data.as_slice()
         );
+        assert_eq!(channel.pending_data.front().unwrap().1, initial_front_ext);
+        assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
+        assert_eq!(channel.pending_data.back().unwrap().1, None);
         assert!(encrypted.write.is_empty());
     }
 
@@ -866,13 +877,25 @@ mod tests {
             .channels
             .insert(channel_id, test_channel(channel_id, 42, false, false));
 
-        let initial_pending = encrypted.channels[&channel_id].pending_data.len();
+        let channel = &encrypted.channels[&channel_id];
+        let initial_pending = channel.pending_data.len();
+        assert!(initial_pending > 0);
+        let initial_front = channel.pending_data.front().unwrap();
+        let initial_front_data = initial_front.0.to_vec();
+        let initial_front_ext = initial_front.1;
+
         encrypted
             .extended_data(channel_id, ext, Bytes::from_static(b"new"), false)
             .unwrap();
 
         let channel = &encrypted.channels[&channel_id];
         assert_eq!(channel.pending_data.len(), initial_pending + 1);
+        assert_eq!(
+            channel.pending_data.front().unwrap().0.as_ref(),
+            initial_front_data.as_slice()
+        );
+        assert_eq!(channel.pending_data.front().unwrap().1, initial_front_ext);
+        assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
         assert_eq!(channel.pending_data.back().unwrap().1, Some(ext));
         assert!(encrypted.write.is_empty());
     }


### PR DESCRIPTION
## Summary

If a channel already has pending data, new `data()` and `extended_data()` writes should be queued behind it. Otherwise, later writes can be staged before earlier queued writes and arrive out of order.

This updates both paths to append new writes to `pending_data` whenever that queue is non-empty.

## Testing

- `cargo test -p russh --lib`