### PR TITLE
Fix CI failures on main

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -28,7 +28,13 @@ serde = ["ssh-key/serde"]
 _bench = ["dep:criterion"]
 
 [dependencies]
+# Compatibility floor pins for cargo-minimal-versions. These are otherwise
+# transitive members of the RustCrypto prerelease stack; some are renamed to
+# coexist with older direct dependency lines.
+aead_0_6 = { package = "aead", version = "0.6.0-rc.10" }
 aes.workspace = true
+aes_0_9 = { package = "aes", version = "0.9.0" }
+aes_gcm_0_11 = { package = "aes-gcm", version = "0.11.0-rc.3" }
 async-trait = { workspace = true, optional = true }
 aws-lc-rs = { version = "1.16.2", optional = true }
 bitflags = "2.0"
@@ -36,8 +42,10 @@ block-padding = { version = "0.3", features = ["std"] }
 byteorder.workspace = true
 bytes.workspace = true
 cbc = { version = "0.1" }
+cbc_0_2 = { package = "cbc", version = "0.2.0" }
 cipher = "0.5.1" # only pinned due to a cargo-minimal-versions failure in 0.5.0
 ctr = "0.9"
+ctr_0_10 = { package = "ctr", version = "0.10.0" }
 curve25519-dalek = "5.0.0-pre.6"
 crypto-bigint = { version = "0.7.0-rc.28", features = ["alloc"] }
 data-encoding = "2.3"
@@ -53,9 +61,13 @@ flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
 generic-array = { version = "1.3.3", features = ["compat-0_14"] }
 getrandom = { version = "0.2.15", features = ["js"] }
+ghash = "0.6.0" # only pinned due to a cargo-minimal-versions failure in 0.6.0-rc.3
 hex-literal = "1"
+hkdf = "0.13.0"
 hmac.workspace = true
+hmac_0_13 = { package = "hmac", version = "0.13.0" }
 inout = { version = "0.1", features = ["std"] }
+keccak = "0.2.0"
 log.workspace = true
 md5 = "0.7"
 ml-kem = "0.3.0-rc.1"
@@ -64,11 +76,13 @@ module-lattice = "0.2"
 # via the `rand_0_10` feature flag. Replace with upstream once a release with
 # rand 0.10 support is published. https://github.com/rust-num/num-bigint/pull/338
 num-bigint = { package = "internal-russh-num-bigint", version = "=0.5.0", features = ["rand_0_10"] }
+num_bigint_0_4 = { package = "num-bigint", version = "0.4.6" }
 # num-integer = "0.1"
 p256 = { version = "0.14.0-rc.7", features = ["ecdh"] }
 p384 = { version = "0.14.0-rc.7", features = ["ecdh"] }
 p521 = { version = "0.14.0-rc.7", features = ["ecdh"] }
 pbkdf2 = "0.12"
+pbkdf2_0_13 = { package = "pbkdf2", version = "0.13.0" }
 pkcs1 = { version = "0.8.0-rc.4", optional = true }
 pkcs5 = "0.8.0-rc.13"
 pkcs8 = { version = "0.11.0-rc.11", features = ["encryption", "std"] }
@@ -81,9 +95,14 @@ russh-cryptovec = { version = "0.59.0", path = "../cryptovec", features = [
   "ssh-encoding",
 ] }
 russh-util = { version = "0.52.0", path = "../russh-util" }
+salsa20 = "0.11.0"
+scrypt = "0.12.0"
 sec1 = { version = "0.8", features = ["der"] }
 sha1.workspace = true
+sha1_0_11 = { package = "sha1", version = "0.11.0" }
 sha2.workspace = true
+sha2_0_11 = { package = "sha2", version = "0.11.0" }
+sha3 = "0.11.0"
 signature.workspace = true
 spki = "0.8.0-rc.4"
 ssh-encoding.workspace = true

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -131,21 +131,12 @@ const CIPHER_ORDER: &[cipher::Name] = &[
     cipher::AES_128_CTR,
 ];
 
-// SHA-1 MAC variants excluded; see HMAC_ORDER for the full list including legacy algorithms.
+// SHA-1 MAC variants are excluded from defaults.
 const SAFE_HMAC_ORDER: &[mac::Name] = &[
     mac::HMAC_SHA512_ETM,
     mac::HMAC_SHA256_ETM,
     mac::HMAC_SHA512,
     mac::HMAC_SHA256,
-];
-
-const HMAC_ORDER: &[mac::Name] = &[
-    mac::HMAC_SHA512_ETM,
-    mac::HMAC_SHA256_ETM,
-    mac::HMAC_SHA512,
-    mac::HMAC_SHA256,
-    mac::HMAC_SHA1_ETM,
-    mac::HMAC_SHA1,
 ];
 
 const COMPRESSION_ORDER: &[compression::Name] = &[


### PR DESCRIPTION
Fixes the failing CI run on `main`: https://github.com/Eugeny/russh/actions/runs/24744494719

- removes the unused legacy `HMAC_ORDER` constant left after excluding SHA-1 MACs from defaults
- pins coherent lower bounds for the RustCrypto prerelease stack so `cargo minimal-versions check --all-features --no-dev-deps` no longer selects mutually incompatible early RCs

Verified locally:
- `cargo fmt --check`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-features -- -D warnings`
- `cargo minimal-versions check --all-features --no-dev-deps`