### PR TITLE
Reduce russh write-path copies with direct Bytes sends

### DIFF
--- a/russh/src/channels/mod.rs
+++ b/russh/src/channels/mod.rs
@@ -359,7 +359,10 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
         Ok(())
     }
 
-    async fn reserve_writable_chunk(&self, remaining: usize) -> usize {
+    async fn reserve_writable_chunk(&self, remaining: usize) -> Result<usize, Error> {
+        if self.max_packet_size == 0 {
+            return Err(Error::Inconsistent);
+        }
         loop {
             let mut window_size = self.window_size.value.lock().await;
             let writable = (self.max_packet_size as usize)
@@ -370,10 +373,11 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
                 if *window_size > 0 {
                     self.window_size.notifier.notify_one();
                 }
-                return writable;
+                return Ok(writable);
             }
+            let notified = self.window_size.notifier.notified();
             drop(window_size);
-            self.window_size.notifier.notified().await;
+            notified.await;
         }
     }
 
@@ -384,7 +388,7 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
 
         let mut offset = 0;
         while offset < data.len() {
-            let writable = self.reserve_writable_chunk(data.len() - offset).await;
+            let writable = self.reserve_writable_chunk(data.len() - offset).await?;
             let end = offset + writable;
             let chunk = data.slice(offset..end);
             let msg = match ext {
@@ -695,8 +699,6 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use tokio::sync::mpsc;
 
     use super::*;
@@ -792,18 +794,15 @@ mod tests {
     async fn data_bytes_waits_for_window_update() {
         let window_size = WindowSizeRef::new(0);
         let (write_half, mut receiver) = test_write_half(window_size.clone(), 1024);
-        let mut send = tokio::spawn(async move {
+        let send = tokio::spawn(async move {
             write_half
                 .data_bytes(Bytes::from_static(b"after-window"))
                 .await
                 .unwrap();
         });
 
-        assert!(
-            tokio::time::timeout(Duration::from_millis(10), &mut send)
-                .await
-                .is_err()
-        );
+        tokio::task::yield_now().await;
+        assert!(!send.is_finished());
 
         window_size.update(1024).await;
         send.await.unwrap();
@@ -814,6 +813,16 @@ mod tests {
             }
             msg => panic!("unexpected message: {msg:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn data_bytes_rejects_zero_max_packet_size() {
+        let (write_half, mut receiver) = test_write_half(WindowSizeRef::new(1024), 0);
+
+        let result = write_half.data_bytes(Bytes::from_static(b"owned")).await;
+
+        assert!(matches!(result, Err(Error::Inconsistent)));
+        assert!(receiver.try_recv().is_err());
     }
 
     #[tokio::test]

--- a/russh/src/channels/mod.rs
+++ b/russh/src/channels/mod.rs
@@ -322,6 +322,11 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
         self.send_data(None, data).await
     }
 
+    /// Send owned bytes to a channel without copying them into the `AsyncWrite` path.
+    pub async fn data_bytes(&self, data: impl Into<Bytes>) -> Result<(), Error> {
+        self.send_bytes(None, data.into()).await
+    }
+
     /// Send data to a channel. The number of bytes added to the
     /// "sending pipeline" (to be processed by the event loop) is
     /// returned.
@@ -333,6 +338,15 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
         self.send_data(Some(ext), data).await
     }
 
+    /// Send owned extended data to a channel without copying it into the `AsyncWrite` path.
+    pub async fn extended_data_bytes(
+        &self,
+        ext: u32,
+        data: impl Into<Bytes>,
+    ) -> Result<(), Error> {
+        self.send_bytes(Some(ext), data.into()).await
+    }
+
     async fn send_data<R: tokio::io::AsyncRead + Unpin>(
         &self,
         ext: Option<u32>,
@@ -341,6 +355,45 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> ChannelWriteHalf<
         let mut tx = self.make_writer_ext(ext);
 
         tokio::io::copy(&mut data, &mut tx).await?;
+
+        Ok(())
+    }
+
+    async fn reserve_writable_chunk(&self, remaining: usize) -> usize {
+        loop {
+            let mut window_size = self.window_size.value.lock().await;
+            let writable = (self.max_packet_size as usize)
+                .min(*window_size as usize)
+                .min(remaining);
+            if writable > 0 {
+                *window_size -= writable as u32;
+                if *window_size > 0 {
+                    self.window_size.notifier.notify_one();
+                }
+                return writable;
+            }
+            drop(window_size);
+            self.window_size.notifier.notified().await;
+        }
+    }
+
+    async fn send_bytes(&self, ext: Option<u32>, data: Bytes) -> Result<(), Error> {
+        if data.is_empty() {
+            return Ok(());
+        }
+
+        let mut offset = 0;
+        while offset < data.len() {
+            let writable = self.reserve_writable_chunk(data.len() - offset).await;
+            let end = offset + writable;
+            let chunk = data.slice(offset..end);
+            let msg = match ext {
+                None => ChannelMsg::Data { data: chunk },
+                Some(ext) => ChannelMsg::ExtendedData { data: chunk, ext },
+            };
+            self.send_msg(msg).await?;
+            offset = end;
+        }
 
         Ok(())
     }
@@ -556,6 +609,11 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
         self.write_half.data(data).await
     }
 
+    /// Send owned bytes to a channel without copying them into the `AsyncWrite` path.
+    pub async fn data_bytes(&self, data: impl Into<Bytes>) -> Result<(), Error> {
+        self.write_half.data_bytes(data).await
+    }
+
     /// Send data to a channel. The number of bytes added to the
     /// "sending pipeline" (to be processed by the event loop) is
     /// returned.
@@ -565,6 +623,15 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
         data: R,
     ) -> Result<(), Error> {
         self.write_half.extended_data(ext, data).await
+    }
+
+    /// Send owned extended data to a channel without copying it into the `AsyncWrite` path.
+    pub async fn extended_data_bytes(
+        &self,
+        ext: u32,
+        data: impl Into<Bytes>,
+    ) -> Result<(), Error> {
+        self.write_half.extended_data_bytes(ext, data).await
     }
 
     pub async fn eof(&self) -> Result<(), Error> {
@@ -623,5 +690,145 @@ impl<S: From<(ChannelId, ChannelMsg)> + Send + Sync + 'static> Channel<S> {
     /// depending on the `ext` parameter, through the `AsyncWrite` trait.
     pub fn make_writer_ext(&self, ext: Option<u32>) -> impl AsyncWrite + 'static {
         self.write_half.make_writer_ext(ext)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+
+    use super::*;
+
+    fn test_write_half(
+        window_size: WindowSizeRef,
+        max_packet_size: u32,
+    ) -> (
+        ChannelWriteHalf<(ChannelId, ChannelMsg)>,
+        mpsc::Receiver<(ChannelId, ChannelMsg)>,
+    ) {
+        let (sender, receiver) = mpsc::channel(8);
+        (
+            ChannelWriteHalf {
+                id: ChannelId(7),
+                sender,
+                max_packet_size,
+                window_size,
+            },
+            receiver,
+        )
+    }
+
+    #[tokio::test]
+    async fn data_bytes_sends_one_owned_message_when_window_permits() {
+        let payload = Bytes::from_static(b"owned data");
+        let (write_half, mut receiver) = test_write_half(WindowSizeRef::new(1024), 1024);
+
+        write_half.data_bytes(payload.clone()).await.unwrap();
+
+        match receiver.recv().await.unwrap() {
+            (ChannelId(7), ChannelMsg::Data { data }) => {
+                assert_eq!(data, payload);
+                assert_eq!(data.as_ptr(), payload.as_ptr());
+            }
+            msg => panic!("unexpected message: {msg:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn data_bytes_splits_by_max_packet_size_without_copying() {
+        let payload = Bytes::from_static(b"abcdefghij");
+        let (write_half, mut receiver) = test_write_half(WindowSizeRef::new(1024), 4);
+
+        write_half.data_bytes(payload.clone()).await.unwrap();
+
+        for (range, expected) in [
+            (0..4, &b"abcd"[..]),
+            (4..8, &b"efgh"[..]),
+            (8..10, &b"ij"[..]),
+        ] {
+            match receiver.recv().await.unwrap() {
+                (ChannelId(7), ChannelMsg::Data { data }) => {
+                    assert_eq!(data.as_ref(), expected);
+                    assert_eq!(data.as_ptr(), payload.slice(range).as_ptr());
+                }
+                msg => panic!("unexpected message: {msg:?}"),
+            }
+        }
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn extended_data_bytes_preserves_extension_code() {
+        let payload = Bytes::from_static(b"stderr");
+        let (write_half, mut receiver) = test_write_half(WindowSizeRef::new(1024), 1024);
+
+        write_half
+            .extended_data_bytes(1, payload.clone())
+            .await
+            .unwrap();
+
+        match receiver.recv().await.unwrap() {
+            (ChannelId(7), ChannelMsg::ExtendedData { data, ext }) => {
+                assert_eq!(ext, 1);
+                assert_eq!(data, payload);
+                assert_eq!(data.as_ptr(), payload.as_ptr());
+            }
+            msg => panic!("unexpected message: {msg:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn data_bytes_empty_payload_sends_nothing() {
+        let (write_half, mut receiver) = test_write_half(WindowSizeRef::new(1024), 1024);
+
+        write_half.data_bytes(Bytes::new()).await.unwrap();
+
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn data_bytes_waits_for_window_update() {
+        let window_size = WindowSizeRef::new(0);
+        let (write_half, mut receiver) = test_write_half(window_size.clone(), 1024);
+        let mut send = tokio::spawn(async move {
+            write_half
+                .data_bytes(Bytes::from_static(b"after-window"))
+                .await
+                .unwrap();
+        });
+
+        assert!(
+            tokio::time::timeout(Duration::from_millis(10), &mut send)
+                .await
+                .is_err()
+        );
+
+        window_size.update(1024).await;
+        send.await.unwrap();
+
+        match receiver.recv().await.unwrap() {
+            (ChannelId(7), ChannelMsg::Data { data }) => {
+                assert_eq!(data.as_ref(), b"after-window");
+            }
+            msg => panic!("unexpected message: {msg:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn channel_data_bytes_forwards_to_write_half() {
+        let (sender, mut receiver) = mpsc::channel(8);
+        let (channel, _reference) =
+            Channel::<(ChannelId, ChannelMsg)>::new(ChannelId(9), sender, 1024, 1024, 8);
+
+        channel.data_bytes(Bytes::from_static(b"channel")).await.unwrap();
+
+        match receiver.recv().await.unwrap() {
+            (ChannelId(9), ChannelMsg::Data { data }) => {
+                assert_eq!(data.as_ref(), b"channel");
+            }
+            msg => panic!("unexpected message: {msg:?}"),
+        }
     }
 }

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -209,6 +209,7 @@ pub(crate) trait SealingKey {
 
     fn seal(&mut self, seqn: u32, plaintext_in_ciphertext_out: &mut [u8], tag_out: &mut [u8]);
 
+    #[allow(clippy::indexing_slicing)] // PacketWriter reserves and sizes the packet buffer first
     fn finish_packet(&mut self, offset: usize, payload_len: usize, buffer: &mut SSHBuffer) {
         let payload_start = offset + PACKET_LENGTH_LEN + PADDING_LENGTH_LEN;
         let payload_end = payload_start + payload_len;
@@ -222,9 +223,8 @@ pub(crate) trait SealingKey {
         // Maximum packet length:
         // https://tools.ietf.org/html/rfc4253#section-6.1
         assert!(packet_length <= u32::MAX as usize);
-        #[allow(clippy::unwrap_used)] // length checked
         BigEndian::write_u32(
-            (&mut buffer.buffer[offset..offset + PACKET_LENGTH_LEN]).try_into().unwrap(),
+            &mut buffer.buffer[offset..offset + PACKET_LENGTH_LEN],
             packet_length as u32,
         );
 

--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -209,6 +209,45 @@ pub(crate) trait SealingKey {
 
     fn seal(&mut self, seqn: u32, plaintext_in_ciphertext_out: &mut [u8], tag_out: &mut [u8]);
 
+    fn finish_packet(&mut self, offset: usize, payload_len: usize, buffer: &mut SSHBuffer) {
+        let payload_start = offset + PACKET_LENGTH_LEN + PADDING_LENGTH_LEN;
+        let payload_end = payload_start + payload_len;
+
+        trace!("writing, seqn = {:?}", buffer.seqn.0);
+        let padding_length = self.padding_length(&buffer.buffer[payload_start..payload_end]);
+        trace!("padding length {padding_length:?}");
+        let packet_length = PADDING_LENGTH_LEN + payload_len + padding_length;
+        trace!("packet_length {packet_length:?}");
+
+        // Maximum packet length:
+        // https://tools.ietf.org/html/rfc4253#section-6.1
+        assert!(packet_length <= u32::MAX as usize);
+        #[allow(clippy::unwrap_used)] // length checked
+        BigEndian::write_u32(
+            (&mut buffer.buffer[offset..offset + PACKET_LENGTH_LEN]).try_into().unwrap(),
+            packet_length as u32,
+        );
+
+        assert!(padding_length <= u8::MAX as usize);
+        buffer.buffer[offset + PACKET_LENGTH_LEN] = padding_length as u8;
+        buffer.buffer.resize(payload_end + padding_length, 0);
+        #[allow(clippy::indexing_slicing)] // length checked
+        self.fill_padding(&mut buffer.buffer[payload_end..]);
+        let tag_offset = buffer.buffer.len();
+        buffer.buffer.resize(tag_offset + self.tag_len(), 0);
+
+        #[allow(clippy::indexing_slicing)] // length checked
+        let (plaintext, tag) =
+            buffer.buffer[offset..].split_at_mut(PACKET_LENGTH_LEN + packet_length);
+
+        self.seal(buffer.seqn.0, plaintext, tag);
+
+        buffer.bytes += payload_len;
+        // Sequence numbers are on 32 bits and wrap.
+        // https://tools.ietf.org/html/rfc4253#section-6.4
+        buffer.seqn += Wrapping(1);
+    }
+
     fn write(&mut self, payload: &[u8], buffer: &mut SSHBuffer) {
         // https://tools.ietf.org/html/rfc4253#section-6
         //
@@ -225,8 +264,9 @@ pub(crate) trait SealingKey {
         // Maximum packet length:
         // https://tools.ietf.org/html/rfc4253#section-6.1
         assert!(packet_length <= u32::MAX as usize);
-        #[allow(clippy::unwrap_used)] // length checked
-        (packet_length as u32).encode(&mut buffer.buffer).unwrap();
+        buffer
+            .buffer
+            .extend_from_slice(&(packet_length as u32).to_be_bytes());
 
         assert!(padding_length <= u8::MAX as usize);
         buffer.buffer.push(padding_length as u8);

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -581,8 +581,11 @@ impl Session {
                     }
                 }
 
-                if let Some(ref mut enc) = self.common.encrypted {
-                    new_size -= enc.flush_pending(channel_num)? as u32;
+                let common = &mut self.common;
+                if let Some(enc) = common.encrypted.as_mut() {
+                    new_size -= enc
+                        .flush_pending_with_writer(&mut common.packet_writer, channel_num)?
+                        as u32;
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.window_size().update(new_size).await;

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -887,7 +887,7 @@ impl Session {
                 } => {
                     debug!("sending ssh-userauth service requset");
                     if !*sent {
-                        self.common.packet_writer.packet(|w| {
+                        self.common.packet_writer.write_packet(|w| {
                             msg::SERVICE_REQUEST.encode(w)?;
                             "ssh-userauth".encode(w)?;
                             Ok(())

--- a/russh/src/client/kex.rs
+++ b/russh/src/client/kex.rs
@@ -115,9 +115,7 @@ impl ClientKex {
 
                 let names = {
                     // read algorithms from packet.
-                    self.exchange
-                        .server_kex_init
-                        .extend_from_slice(&input.buffer);
+                    self.exchange.server_kex_init = input.buffer.clone().into();
                     negotiation::Client::read_kex(
                         &input.buffer,
                         &self.config.preferred,
@@ -147,7 +145,7 @@ impl ClientKex {
                         self.cause.session_id(),
                     )?;
 
-                    output.packet(|w| {
+                    output.write_packet(|w| {
                         msg::NEWKEYS.encode(w)?;
                         Ok(())
                     })?;
@@ -159,14 +157,14 @@ impl ClientKex {
                 }
 
                 if kex.is_dh_gex() {
-                    output.packet(|w| {
+                    output.write_packet(|w| {
                         kex.client_dh_gex_init(&self.config.gex, w)?;
                         Ok(())
                     })?;
 
                     self.state = ClientKexState::WaitingForGexReply { names, kex };
                 } else {
-                    output.packet(|w| {
+                    output.write_packet(|w| {
                         kex.client_dh(&mut self.exchange.client_ephemeral, w)?;
                         Ok(())
                     })?;
@@ -217,7 +215,7 @@ impl ClientKex {
                 let exchange = &mut self.exchange;
                 exchange.gex = Some((self.config.gex.clone(), group.clone()));
                 kex.dh_gex_set_group(group)?;
-                output.packet(|w| {
+                output.write_packet(|w| {
                     kex.client_dh(&mut exchange.client_ephemeral, w)?;
                     Ok(())
                 })?;
@@ -306,7 +304,7 @@ impl ClientKex {
                     self.cause.session_id(),
                 )?;
 
-                output.packet(|w| {
+                output.write_packet(|w| {
                     msg::NEWKEYS.encode(w)?;
                     Ok(())
                 })?;

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -1612,18 +1612,20 @@ async fn reply<H: Handler>(
                         // This is a rekey
                         {
                             let common = &mut session.common;
-                            let enc = common.encrypted.as_mut().expect("checked encrypted");
-                            enc.last_rekey = Instant::now();
+                            common.newkeys(newkeys);
                             common.packet_writer.buffer().bytes = 0;
-                            enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                            if let Some(enc) = common.encrypted.as_mut() {
+                                enc.last_rekey = Instant::now();
+                                enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                            }
                         }
+
                         let mut pending = std::mem::take(&mut session.pending_reads);
                         for p in pending.drain(..) {
                             session.process_packet(handler, &p).await?;
                         }
                         session.pending_reads = pending;
                         session.pending_len = 0;
-                        session.common.newkeys(newkeys);
                     } else {
                         // This is the initial kex
                         if let Some(server_host_key) = &server_host_key {

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -890,7 +890,7 @@ impl<H: Handler> Handle<H> {
     ) -> Result<(), bytes::Bytes> {
         let data = data.into();
         self.sender
-            .send(Msg::Channel(id, ChannelMsg::Data { data: data.clone() }))
+            .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
             .map_err(|e| match e.0 {
                 Msg::Channel(_, ChannelMsg::Data { data, .. }) => data,

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -1608,11 +1608,15 @@ async fn reply<H: Handler>(
                         .kex_done(shared_secret, &newkeys.names, session)
                         .await?;
 
-                    if let Some(ref mut enc) = session.common.encrypted {
+                    if session.common.encrypted.is_some() {
                         // This is a rekey
-                        enc.last_rekey = Instant::now();
-                        session.common.packet_writer.buffer().bytes = 0;
-                        enc.flush_all_pending()?;
+                        {
+                            let common = &mut session.common;
+                            let enc = common.encrypted.as_mut().expect("checked encrypted");
+                            enc.last_rekey = Instant::now();
+                            common.packet_writer.buffer().bytes = 0;
+                            enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                        }
                         let mut pending = std::mem::take(&mut session.pending_reads);
                         for p in pending.drain(..) {
                             session.process_packet(handler, &p).await?;

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -443,8 +443,10 @@ impl Session {
     }
 
     pub fn data(&mut self, channel: ChannelId, data: impl Into<bytes::Bytes>) -> Result<(), crate::Error> {
-        if let Some(ref mut enc) = self.common.encrypted {
-            enc.data(channel, data, self.kex.active())
+        let is_rekeying = self.kex.active();
+        let common = &mut self.common;
+        if let Some(enc) = common.encrypted.as_mut() {
+            enc.data_with_writer(&mut common.packet_writer, channel, data, is_rekeying)
         } else {
             unreachable!()
         }
@@ -472,8 +474,10 @@ impl Session {
         ext: u32,
         data: impl Into<bytes::Bytes>,
     ) -> Result<(), crate::Error> {
-        if let Some(ref mut enc) = self.common.encrypted {
-            enc.extended_data(channel, ext, data, self.kex.active())
+        let is_rekeying = self.kex.active();
+        let common = &mut self.common;
+        if let Some(enc) = common.encrypted.as_mut() {
+            enc.extended_data_with_writer(&mut common.packet_writer, channel, ext, data, is_rekeying)
         } else {
             unreachable!()
         }

--- a/russh/src/compression.rs
+++ b/russh/src/compression.rs
@@ -142,6 +142,17 @@ impl Compress {
     ) -> Result<&'a [u8], crate::Error> {
         Ok(input)
     }
+
+    pub fn compress_into(
+        &mut self,
+        input: &[u8],
+        output: &mut Vec<u8>,
+        start_len: usize,
+    ) -> Result<usize, crate::Error> {
+        output.truncate(start_len);
+        output.extend_from_slice(input);
+        Ok(input.len())
+    }
 }
 
 #[cfg(not(feature = "flate2"))]
@@ -157,6 +168,10 @@ impl Decompress {
 
 #[cfg(feature = "flate2")]
 impl Compress {
+    fn zlib_output_reserve_bound(input_len: usize) -> usize {
+        input_len.saturating_add(10)
+    }
+
     pub fn compress<'a>(
         &mut self,
         input: &'a [u8],
@@ -185,6 +200,45 @@ impl Compress {
                 let n_out_ = z.total_out() as usize - n_out;
                 #[allow(clippy::indexing_slicing)] // length checked
                 Ok(&output[..n_out_])
+            }
+        }
+    }
+
+    pub fn compress_into(
+        &mut self,
+        input: &[u8],
+        output: &mut Vec<u8>,
+        start_len: usize,
+    ) -> Result<usize, crate::Error> {
+        match *self {
+            Compress::None => {
+                output.truncate(start_len);
+                output.extend_from_slice(input);
+                Ok(input.len())
+            }
+            Compress::Zlib(ref mut z) => {
+                output.truncate(start_len);
+                let n_in = z.total_in() as usize;
+                let n_out = z.total_out() as usize;
+                let reserve = Self::zlib_output_reserve_bound(input.len());
+                output.resize(start_len + reserve, 0);
+                let flush = flate2::FlushCompress::Partial;
+                loop {
+                    let n_in_ = z.total_in() as usize - n_in;
+                    let n_out_ = z.total_out() as usize - n_out;
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    let c = z.compress(&input[n_in_..], &mut output[start_len + n_out_..], flush)?;
+                    match c {
+                        flate2::Status::BufError => {
+                            let growth = output.len().saturating_sub(start_len).max(1);
+                            output.resize(output.len() + growth, 0);
+                        }
+                        _ => break,
+                    }
+                }
+                let n_out_ = z.total_out() as usize - n_out;
+                output.truncate(start_len + n_out_);
+                Ok(n_out_)
             }
         }
     }

--- a/russh/src/kex/hybrid_mlkem.rs
+++ b/russh/src/kex/hybrid_mlkem.rs
@@ -335,8 +335,8 @@ mod tests {
         let mut exchange = Exchange {
             client_id: b"SSH-2.0-Test_Client".to_vec(),
             server_id: b"SSH-2.0-Test_Server".to_vec(),
-            client_kex_init: b"client_kex_init".to_vec(),
-            server_kex_init: b"server_kex_init".to_vec(),
+            client_kex_init: bytes::Bytes::from_static(b"client_kex_init"),
+            server_kex_init: bytes::Bytes::from_static(b"server_kex_init"),
             client_ephemeral: client_ephemeral.clone(),
             server_ephemeral: Vec::new(),
             gex: None,

--- a/russh/src/lib_inner.rs
+++ b/russh/src/lib_inner.rs
@@ -3,7 +3,7 @@ use std::fmt::{Debug, Display, Formatter};
 use std::future::{Future, Pending};
 
 use futures::future::Either as EitherFuture;
-use log::{debug, warn};
+use log::warn;
 use parsing::ChannelOpenConfirmation;
 pub use russh_cryptovec::CryptoVec;
 use ssh_encoding::{Decode, Encode};

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -421,7 +421,6 @@ pub(crate) fn write_kex(
     server_config: Option<&Config>,
 ) -> Result<Bytes, Error> {
     writer.packet_bytes(|w| {
-        // buf.clear();
         msg::KEXINIT.encode(w)?;
 
         let mut cookie = [0; 16];

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -420,7 +420,7 @@ pub(crate) fn write_kex(
     writer: &mut PacketWriter,
     server_config: Option<&Config>,
 ) -> Result<Bytes, Error> {
-    writer.packet(|w| {
+    writer.packet_bytes(|w| {
         // buf.clear();
         msg::KEXINIT.encode(w)?;
 

--- a/russh/src/negotiation.rs
+++ b/russh/src/negotiation.rs
@@ -14,6 +14,7 @@
 //
 use std::borrow::Cow;
 
+use bytes::Bytes;
 use log::debug;
 use rand_core::Rng;
 use ssh_encoding::{Decode, Encode};
@@ -418,7 +419,7 @@ pub(crate) fn write_kex(
     prefs: &Preferred,
     writer: &mut PacketWriter,
     server_config: Option<&Config>,
-) -> Result<Vec<u8>, Error> {
+) -> Result<Bytes, Error> {
     writer.packet(|w| {
         // buf.clear();
         msg::KEXINIT.encode(w)?;

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -683,7 +683,9 @@ impl Session {
                 }
                 let common = &mut self.common;
                 if let Some(enc) = common.encrypted.as_mut() {
-                    enc.flush_pending_with_writer(&mut common.packet_writer, channel_num)?;
+                    new_size -= enc
+                        .flush_pending_with_writer(&mut common.packet_writer, channel_num)?
+                        as u32;
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.window_size().update(new_size).await;

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -681,8 +681,9 @@ impl Session {
                         return Ok(());
                     }
                 }
-                if let Some(ref mut enc) = self.common.encrypted {
-                    enc.flush_pending(channel_num)?;
+                let common = &mut self.common;
+                if let Some(enc) = common.encrypted.as_mut() {
+                    enc.flush_pending_with_writer(&mut common.packet_writer, channel_num)?;
                 }
                 if let Some(chan) = self.channels.get(&channel_num) {
                     chan.window_size().update(new_size).await;

--- a/russh/src/server/kex.rs
+++ b/russh/src/server/kex.rs
@@ -109,7 +109,7 @@ impl ServerKex {
                 }
 
                 let names = {
-                    self.exchange.client_kex_init.extend_from_slice(&input.buffer);
+                    self.exchange.client_kex_init = input.buffer.clone().into();
                     negotiation::Server::read_kex(
                         &input.buffer,
                         &self.config.preferred,
@@ -138,7 +138,7 @@ impl ServerKex {
                         self.cause.session_id(),
                     )?;
 
-                    output.packet(|w| {
+                    output.write_packet(|w| {
                         msg::NEWKEYS.encode(w)?;
                         Ok(())
                     })?;
@@ -187,7 +187,7 @@ impl ServerKex {
                 self.exchange.gex = Some((gex_params, dh_group.clone()));
                 kex.dh_gex_set_group(dh_group)?;
 
-                output.packet(|w| {
+                output.write_packet(|w| {
                     msg::KEX_DH_GEX_GROUP.encode(w)?;
                     prime.encode(w)?;
                     generator.encode(w)?;
@@ -278,7 +278,7 @@ impl ServerKex {
                 )
                 .map_err(Into::into)?;
 
-                output.packet(|w| {
+                output.write_packet(|w| {
                     match kex.is_dh_gex() {
                         true => &msg::KEX_DH_GEX_REPLY,
                         false => &msg::KEX_ECDH_REPLY,
@@ -290,7 +290,7 @@ impl ServerKex {
                     Ok(())
                 })?;
 
-                output.packet(|w| {
+                output.write_packet(|w| {
                     msg::NEWKEYS.encode(w)?;
                     Ok(())
                 })?;

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -1120,10 +1120,12 @@ async fn reply<H: Handler + Send>(
                         // This is a rekey
                         {
                             let common = &mut session.common;
-                            let enc = common.encrypted.as_mut().expect("checked encrypted");
-                            enc.last_rekey = Instant::now();
+                            common.newkeys(newkeys);
                             common.packet_writer.buffer().bytes = 0;
-                            enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                            if let Some(enc) = common.encrypted.as_mut() {
+                                enc.last_rekey = Instant::now();
+                                enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                            }
                         }
 
                         let mut pending = std::mem::take(&mut session.pending_reads);
@@ -1132,7 +1134,6 @@ async fn reply<H: Handler + Send>(
                         }
                         session.pending_reads = pending;
                         session.pending_len = 0;
-                        session.common.newkeys(newkeys);
                         session.flush()?;
                     } else {
                         // This is the initial kex

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -1116,11 +1116,15 @@ async fn reply<H: Handler + Send>(
                     session.common.strict_kex =
                         session.common.strict_kex || newkeys.names.strict_kex();
 
-                    if let Some(ref mut enc) = session.common.encrypted {
+                    if session.common.encrypted.is_some() {
                         // This is a rekey
-                        enc.last_rekey = Instant::now();
-                        session.common.packet_writer.buffer().bytes = 0;
-                        enc.flush_all_pending()?;
+                        {
+                            let common = &mut session.common;
+                            let enc = common.encrypted.as_mut().expect("checked encrypted");
+                            enc.last_rekey = Instant::now();
+                            common.packet_writer.buffer().bytes = 0;
+                            enc.flush_all_pending_with_writer(&mut common.packet_writer)?;
+                        }
 
                         let mut pending = std::mem::take(&mut session.pending_reads);
                         for p in pending.drain(..) {

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -104,9 +104,7 @@ impl Handle {
     pub async fn data(&self, id: ChannelId, data: impl Into<bytes::Bytes>) -> Result<(), bytes::Bytes> {
         let data = data.into();
         self.sender
-            .send(Msg::Channel(id, ChannelMsg::Data {
-                data: data.clone(),
-            }))
+            .send(Msg::Channel(id, ChannelMsg::Data { data }))
             .await
             .map_err(|e| match e.0 {
                 Msg::Channel(_, ChannelMsg::Data { data }) => data,
@@ -125,7 +123,7 @@ impl Handle {
         self.sender
             .send(Msg::Channel(id, ChannelMsg::ExtendedData {
                 ext,
-                data: data.clone(),
+                data,
             }))
             .await
             .map_err(|e| match e.0 {

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -917,8 +917,10 @@ impl Session {
     /// The number of bytes added to the "sending pipeline" (to be
     /// processed by the event loop) is returned.
     pub fn data(&mut self, channel: ChannelId, data: impl Into<bytes::Bytes>) -> Result<(), Error> {
-        if let Some(ref mut enc) = self.common.encrypted {
-            enc.data(channel, data, self.kex.active())
+        let is_rekeying = self.kex.active();
+        let common = &mut self.common;
+        if let Some(enc) = common.encrypted.as_mut() {
+            enc.data_with_writer(&mut common.packet_writer, channel, data, is_rekeying)
         } else {
             unreachable!()
         }
@@ -936,8 +938,16 @@ impl Session {
         extended: u32,
         data: impl Into<bytes::Bytes>,
     ) -> Result<(), Error> {
-        if let Some(ref mut enc) = self.common.encrypted {
-            enc.extended_data(channel, extended, data, self.kex.active())
+        let is_rekeying = self.kex.active();
+        let common = &mut self.common;
+        if let Some(enc) = common.encrypted.as_mut() {
+            enc.extended_data_with_writer(
+                &mut common.packet_writer,
+                channel,
+                extended,
+                data,
+                is_rekeying,
+            )
         } else {
             unreachable!()
         }

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -18,6 +18,7 @@ use std::fmt::{Debug, Formatter};
 use std::mem::replace;
 use std::num::Wrapping;
 
+use bytes::Bytes;
 use byteorder::{BigEndian, ByteOrder};
 use log::{debug, trace};
 use ssh_encoding::Encode;
@@ -443,7 +444,7 @@ impl Encrypted {
     pub fn data(
         &mut self,
         channel: ChannelId,
-        buf0: impl Into<bytes::Bytes>,
+        buf0: impl Into<Bytes>,
         is_rekeying: bool,
     ) -> Result<(), crate::Error> {
         let buf0 = buf0.into();
@@ -467,7 +468,7 @@ impl Encrypted {
         &mut self,
         channel: ChannelId,
         ext: u32,
-        buf0: impl Into<bytes::Bytes>,
+        buf0: impl Into<Bytes>,
         is_rekeying: bool,
     ) -> Result<(), crate::Error> {
         let buf0 = buf0.into();
@@ -571,8 +572,8 @@ pub struct Exchange {
     // They carry no secret material and do not require mlock.
     pub client_id: Vec<u8>,
     pub server_id: Vec<u8>,
-    pub client_kex_init: Vec<u8>,
-    pub server_kex_init: Vec<u8>,
+    pub client_kex_init: Bytes,
+    pub server_kex_init: Bytes,
     pub client_ephemeral: Vec<u8>,
     pub server_ephemeral: Vec<u8>,
     pub gex: Option<(GexParams, DhGroup)>,

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -448,16 +448,17 @@ impl Encrypted {
         if from >= buf0.len() {
             return Ok(0);
         }
-        let mut buf = if buf0.len() as u32 > from as u32 + channel.recipient_window_size {
-            #[allow(clippy::indexing_slicing)] // length checked
-            &buf0[from..from + channel.recipient_window_size as usize]
-        } else {
-            #[allow(clippy::indexing_slicing)] // length checked
-            &buf0[from..]
-        };
+        let window_end = from
+            .checked_add(channel.recipient_window_size as usize)
+            .unwrap_or(usize::MAX);
+        let end = std::cmp::min(buf0.len(), window_end);
+        #[allow(clippy::indexing_slicing)] // length checked
+        let mut buf = &buf0[from..end];
         let buf_len = buf.len();
         let max_packet_size = channel.recipient_maximum_packet_size as usize;
-        assert!(max_packet_size > 0);
+        if max_packet_size == 0 {
+            return Err(crate::Error::Inconsistent);
+        }
         let packet_count = buf_len.div_ceil(max_packet_size);
         let packet_overhead = match a {
             None => 4 + 1 + 4 + 4,
@@ -509,16 +510,17 @@ impl Encrypted {
             return Ok(0);
         }
         let buf0 = buf0.as_ref();
-        let mut buf = if buf0.len() as u32 > from as u32 + channel.recipient_window_size {
-            #[allow(clippy::indexing_slicing)] // length checked
-            &buf0[from..from + channel.recipient_window_size as usize]
-        } else {
-            #[allow(clippy::indexing_slicing)] // length checked
-            &buf0[from..]
-        };
+        let window_end = from
+            .checked_add(channel.recipient_window_size as usize)
+            .unwrap_or(usize::MAX);
+        let end = std::cmp::min(buf0.len(), window_end);
+        #[allow(clippy::indexing_slicing)] // length checked
+        let mut buf = &buf0[from..end];
         let buf_len = buf.len();
         let max_packet_size = channel.recipient_maximum_packet_size as usize;
-        assert!(max_packet_size > 0);
+        if max_packet_size == 0 {
+            return Err(crate::Error::Inconsistent);
+        }
         let packet_count = buf_len.div_ceil(max_packet_size);
         let channel_payload_overhead = match a {
             None => 1 + 4 + 4,
@@ -1363,6 +1365,39 @@ mod tests {
         );
         assert!(encrypted.channels[&channel_id].pending_data.is_empty());
         assert_eq!(encrypted.channels[&channel_id].recipient_window_size, 0);
+    }
+
+    #[test]
+    fn data_staged_rejects_zero_recipient_max_packet_size() {
+        let channel_id = ChannelId(27);
+        let mut encrypted = test_encrypted();
+        let mut channel = test_ready_channel(channel_id, 49);
+        channel.recipient_maximum_packet_size = 0;
+        encrypted.channels.insert(channel_id, channel);
+
+        let result = encrypted.data(channel_id, Bytes::from_static(b"new"), false);
+
+        assert!(matches!(result, Err(crate::Error::Inconsistent)));
+        assert!(encrypted.write.is_empty());
+        assert_eq!(encrypted.channels[&channel_id].recipient_window_size, 1024);
+    }
+
+    #[test]
+    fn data_direct_rejects_zero_recipient_max_packet_size() {
+        let channel_id = ChannelId(28);
+        let mut encrypted = test_encrypted();
+        let mut channel = test_ready_channel(channel_id, 50);
+        channel.recipient_maximum_packet_size = 0;
+        encrypted.channels.insert(channel_id, channel);
+
+        let mut writer = PacketWriter::clear();
+        let result =
+            encrypted.data_with_writer(&mut writer, channel_id, Bytes::from_static(b"new"), false);
+
+        assert!(matches!(result, Err(crate::Error::Inconsistent)));
+        assert!(writer.buffer().buffer.is_empty());
+        assert!(encrypted.write.is_empty());
+        assert_eq!(encrypted.channels[&channel_id].recipient_window_size, 1024);
     }
 
     #[test]

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -808,34 +808,43 @@ mod tests {
     }
 
     #[test]
-    fn flush_all_pending_handles_multiple_channels_independently() {
-        let eof_only = ChannelId(3);
-        let close_too = ChannelId(4);
+    fn flush_all_pending_replays_deferred_controls_across_channels() {
+        let channel_a = ChannelId(3);
+        let channel_b = ChannelId(4);
         let mut encrypted = test_encrypted();
         encrypted
             .channels
-            .insert(eof_only, test_channel(eof_only, 50, true, false));
+            .insert(channel_a, test_channel(channel_a, 44, true, false));
         encrypted
             .channels
-            .insert(close_too, test_channel(close_too, 51, true, true));
+            .insert(channel_b, test_channel(channel_b, 45, false, true));
 
         encrypted.flush_all_pending().unwrap();
 
-        // eof_only: data + EOF, channel still present
-        assert!(encrypted.channels.contains_key(&eof_only));
-        assert!(!encrypted.channels[&eof_only].pending_eof);
-
-        // close_too: data + EOF + CLOSE, channel removed
-        assert!(!encrypted.channels.contains_key(&close_too));
-
-        // Combined wire output contains both sets of packets (order may vary by map iteration).
-        let types = packet_types(&encrypted.write);
-        assert_eq!(types.iter().filter(|&&t| t == msg::CHANNEL_DATA).count(), 2);
-        assert_eq!(types.iter().filter(|&&t| t == msg::CHANNEL_EOF).count(), 2);
+        let packet_types = packet_types(&encrypted.write);
         assert_eq!(
-            types.iter().filter(|&&t| t == msg::CHANNEL_CLOSE).count(),
+            packet_types
+                .iter()
+                .filter(|&&msg_type| msg_type == msg::CHANNEL_DATA)
+                .count(),
+            2
+        );
+        assert_eq!(
+            packet_types
+                .iter()
+                .filter(|&&msg_type| msg_type == msg::CHANNEL_EOF)
+                .count(),
             1
         );
+        assert_eq!(
+            packet_types
+                .iter()
+                .filter(|&&msg_type| msg_type == msg::CHANNEL_CLOSE)
+                .count(),
+            1
+        );
+        assert!(encrypted.channels.contains_key(&channel_a));
+        assert!(!encrypted.channels.contains_key(&channel_b));
     }
 
     #[test]

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -333,6 +333,29 @@ impl Encrypted {
         Ok(ChannelFlushResult::complete(pending_size, channel))
     }
 
+    fn flush_channel_with_writer(
+        write: &mut Vec<u8>,
+        writer: &mut PacketWriter,
+        channel: &mut ChannelParams,
+    ) -> Result<ChannelFlushResult, crate::Error> {
+        let mut pending_size = 0;
+        while let Some((buf, a, from)) = channel.pending_data.pop_front() {
+            let size = if write.is_empty() {
+                Self::data_noqueue_direct(writer, channel, &buf, a, from)?
+            } else {
+                Self::data_noqueue(write, channel, &buf, a, from)?
+            };
+            pending_size += size;
+            if from + size < buf.len() {
+                channel.pending_data.push_front((buf, a, from + size));
+                return Ok(ChannelFlushResult::Incomplete {
+                    wrote: pending_size,
+                });
+            }
+        }
+        Ok(ChannelFlushResult::complete(pending_size, channel))
+    }
+
     fn handle_flushed_channel(
         &mut self,
         channel: ChannelId,
@@ -364,10 +387,36 @@ impl Encrypted {
         Ok(wrote)
     }
 
+    pub fn flush_pending_with_writer(
+        &mut self,
+        writer: &mut PacketWriter,
+        channel: ChannelId,
+    ) -> Result<usize, crate::Error> {
+        let flush_result = match self.channels.get_mut(&channel) {
+            Some(ch) => Self::flush_channel_with_writer(&mut self.write, writer, ch)?,
+            None => return Ok(0),
+        };
+        let wrote = flush_result.wrote();
+        self.handle_flushed_channel(channel, flush_result)?;
+        Ok(wrote)
+    }
+
+    #[allow(dead_code)]
     pub fn flush_all_pending(&mut self) -> Result<(), crate::Error> {
         let channel_ids: Vec<ChannelId> = self.channels.keys().copied().collect();
         for channel_id in channel_ids {
             self.flush_pending(channel_id)?;
+        }
+        Ok(())
+    }
+
+    pub fn flush_all_pending_with_writer(
+        &mut self,
+        writer: &mut PacketWriter,
+    ) -> Result<(), crate::Error> {
+        let channel_ids: Vec<ChannelId> = self.channels.keys().copied().collect();
+        for channel_id in channel_ids {
+            self.flush_pending_with_writer(writer, channel_id)?;
         }
         Ok(())
     }
@@ -1052,6 +1101,135 @@ mod tests {
         assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
         assert_eq!(channel.pending_data.back().unwrap().1, Some(ext));
         assert!(encrypted.write.is_empty());
+    }
+
+    #[test]
+    fn flush_pending_with_writer_matches_staged_channel_data() {
+        let channel_id = ChannelId(7);
+        let mut staged = test_encrypted();
+        let mut direct = test_encrypted();
+        staged
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, false, false));
+        direct
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, false, false));
+
+        let mut staged_writer = PacketWriter::clear();
+        staged.flush_pending(channel_id).unwrap();
+        staged
+            .flush(&Limits::default(), &mut staged_writer)
+            .unwrap();
+
+        let mut direct_writer = PacketWriter::clear();
+        direct
+            .flush_pending_with_writer(&mut direct_writer, channel_id)
+            .unwrap();
+
+        assert_eq!(direct_writer.buffer().buffer, staged_writer.buffer().buffer);
+        assert_eq!(
+            direct.channels[&channel_id].recipient_window_size,
+            staged.channels[&channel_id].recipient_window_size
+        );
+        assert!(direct.channels[&channel_id].pending_data.is_empty());
+    }
+
+    #[test]
+    fn flush_pending_with_writer_matches_staged_extended_data() {
+        let channel_id = ChannelId(8);
+        let mut staged = test_encrypted();
+        let mut direct = test_encrypted();
+        let mut staged_channel = test_channel(channel_id, 42, false, false);
+        staged_channel.pending_data =
+            VecDeque::from([(Bytes::from_static(b"hello"), Some(1), 0)]);
+        let mut direct_channel = test_channel(channel_id, 42, false, false);
+        direct_channel.pending_data =
+            VecDeque::from([(Bytes::from_static(b"hello"), Some(1), 0)]);
+        staged.channels.insert(channel_id, staged_channel);
+        direct.channels.insert(channel_id, direct_channel);
+
+        let mut staged_writer = PacketWriter::clear();
+        staged.flush_pending(channel_id).unwrap();
+        staged
+            .flush(&Limits::default(), &mut staged_writer)
+            .unwrap();
+
+        let mut direct_writer = PacketWriter::clear();
+        direct
+            .flush_pending_with_writer(&mut direct_writer, channel_id)
+            .unwrap();
+
+        assert_eq!(direct_writer.buffer().buffer, staged_writer.buffer().buffer);
+        assert!(direct.channels[&channel_id].pending_data.is_empty());
+    }
+
+    #[test]
+    fn flush_pending_with_writer_falls_back_when_write_queue_nonempty() {
+        let channel_id = ChannelId(9);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, false, false));
+        push_packet!(encrypted.write, encrypted.write.push(msg::REQUEST_SUCCESS));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .flush_pending_with_writer(&mut writer, channel_id)
+            .unwrap();
+
+        assert!(writer.buffer().buffer.is_empty());
+        assert_eq!(
+            packet_types(&encrypted.write),
+            vec![msg::REQUEST_SUCCESS, msg::CHANNEL_DATA]
+        );
+    }
+
+    #[test]
+    fn flush_pending_with_writer_preserves_partial_window_remainder() {
+        let channel_id = ChannelId(13);
+        let payload = Bytes::from_static(b"abcdef");
+        let mut encrypted = test_encrypted();
+        let mut channel = test_channel_windowed(channel_id, 42, 3, false, false);
+        channel.pending_data = VecDeque::from([(payload.clone(), None, 0)]);
+        encrypted.channels.insert(channel_id, channel);
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .flush_pending_with_writer(&mut writer, channel_id)
+            .unwrap();
+
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(
+            clear_packet_types(&writer.buffer().buffer),
+            vec![msg::CHANNEL_DATA]
+        );
+        assert_eq!(channel.recipient_window_size, 0);
+        assert_eq!(channel.pending_data.len(), 1);
+        let pending = channel.pending_data.back().unwrap();
+        assert_eq!(pending.0, payload);
+        assert_eq!(pending.1, None);
+        assert_eq!(pending.2, 3);
+    }
+
+    #[test]
+    fn flush_pending_with_writer_emits_controls_after_replayed_data() {
+        let channel_id = ChannelId(14);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_channel(channel_id, 42, true, true));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .flush_pending_with_writer(&mut writer, channel_id)
+            .unwrap();
+        encrypted.flush(&Limits::default(), &mut writer).unwrap();
+
+        assert_eq!(
+            clear_packet_types(&writer.buffer().buffer),
+            vec![msg::CHANNEL_DATA, msg::CHANNEL_EOF, msg::CHANNEL_CLOSE]
+        );
+        assert!(!encrypted.channels.contains_key(&channel_id));
     }
 
     #[test]

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -407,10 +407,18 @@ impl Encrypted {
             &buf0[from..]
         };
         let buf_len = buf.len();
+        let max_packet_size = channel.recipient_maximum_packet_size as usize;
+        assert!(max_packet_size > 0);
+        let packet_count = buf_len.div_ceil(max_packet_size);
+        let packet_overhead = match a {
+            None => 4 + 1 + 4 + 4,
+            Some(_) => 4 + 1 + 4 + 4 + 4,
+        };
+        write.reserve(buf_len.saturating_add(packet_count.saturating_mul(packet_overhead)));
 
         while !buf.is_empty() {
             // Compute the length we're allowed to send.
-            let off = std::cmp::min(buf.len(), channel.recipient_maximum_packet_size as usize);
+            let off = std::cmp::min(buf.len(), max_packet_size);
             match a {
                 None => push_packet!(write, {
                     write.push(msg::CHANNEL_DATA);
@@ -441,6 +449,66 @@ impl Encrypted {
         Ok(buf_len)
     }
 
+    fn data_noqueue_direct(
+        writer: &mut PacketWriter,
+        channel: &mut ChannelParams,
+        buf0: &Bytes,
+        a: Option<u32>,
+        from: usize,
+    ) -> Result<usize, crate::Error> {
+        if from >= buf0.len() {
+            return Ok(0);
+        }
+        let buf0 = buf0.as_ref();
+        let mut buf = if buf0.len() as u32 > from as u32 + channel.recipient_window_size {
+            #[allow(clippy::indexing_slicing)] // length checked
+            &buf0[from..from + channel.recipient_window_size as usize]
+        } else {
+            #[allow(clippy::indexing_slicing)] // length checked
+            &buf0[from..]
+        };
+        let buf_len = buf.len();
+        let max_packet_size = channel.recipient_maximum_packet_size as usize;
+        assert!(max_packet_size > 0);
+        let packet_count = buf_len.div_ceil(max_packet_size);
+        let channel_payload_overhead = match a {
+            None => 1 + 4 + 4,
+            Some(_) => 1 + 4 + 4 + 4,
+        };
+        writer.reserve_cleartext_packet_output(
+            buf_len.saturating_add(packet_count.saturating_mul(channel_payload_overhead)),
+            packet_count,
+        );
+
+        while !buf.is_empty() {
+            let off = std::cmp::min(buf.len(), max_packet_size);
+            match a {
+                None => writer.write_packet(|packet| {
+                    packet.push(msg::CHANNEL_DATA);
+                    channel.recipient_channel.encode(packet)?;
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    buf[..off].encode(packet)?;
+                    Ok(())
+                })?,
+                Some(ext) => writer.write_packet(|packet| {
+                    packet.push(msg::CHANNEL_EXTENDED_DATA);
+                    channel.recipient_channel.encode(packet)?;
+                    ext.encode(packet)?;
+                    #[allow(clippy::indexing_slicing)] // length checked
+                    buf[..off].encode(packet)?;
+                    Ok(())
+                })?,
+            }
+            channel.recipient_window_size -= off as u32;
+            #[allow(clippy::indexing_slicing)] // length checked
+            {
+                buf = &buf[off..]
+            }
+        }
+        Ok(buf_len)
+    }
+
+    #[allow(dead_code)]
     pub fn data(
         &mut self,
         channel: ChannelId,
@@ -464,6 +532,35 @@ impl Encrypted {
         Ok(())
     }
 
+    pub fn data_with_writer(
+        &mut self,
+        writer: &mut PacketWriter,
+        channel: ChannelId,
+        buf0: impl Into<Bytes>,
+        is_rekeying: bool,
+    ) -> Result<(), crate::Error> {
+        let buf0 = buf0.into();
+        if let Some(channel) = self.channels.get_mut(&channel) {
+            assert!(channel.confirmed);
+            if !channel.pending_data.is_empty() || is_rekeying {
+                channel.pending_data.push_back((buf0, None, 0));
+                return Ok(());
+            }
+            let buf_len = if self.write.is_empty() {
+                Self::data_noqueue_direct(writer, channel, &buf0, None, 0)?
+            } else {
+                Self::data_noqueue(&mut self.write, channel, &buf0, None, 0)?
+            };
+            if buf_len < buf0.len() {
+                channel.pending_data.push_back((buf0, None, buf_len))
+            }
+        } else {
+            debug!("{channel:?} not saved for this session");
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
     pub fn extended_data(
         &mut self,
         channel: ChannelId,
@@ -479,6 +576,33 @@ impl Encrypted {
                 return Ok(());
             }
             let buf_len = Self::data_noqueue(&mut self.write, channel, &buf0, Some(ext), 0)?;
+            if buf_len < buf0.len() {
+                channel.pending_data.push_back((buf0, Some(ext), buf_len))
+            }
+        }
+        Ok(())
+    }
+
+    pub fn extended_data_with_writer(
+        &mut self,
+        writer: &mut PacketWriter,
+        channel: ChannelId,
+        ext: u32,
+        buf0: impl Into<Bytes>,
+        is_rekeying: bool,
+    ) -> Result<(), crate::Error> {
+        let buf0 = buf0.into();
+        if let Some(channel) = self.channels.get_mut(&channel) {
+            assert!(channel.confirmed);
+            if !channel.pending_data.is_empty() || is_rekeying {
+                channel.pending_data.push_back((buf0, Some(ext), 0));
+                return Ok(());
+            }
+            let buf_len = if self.write.is_empty() {
+                Self::data_noqueue_direct(writer, channel, &buf0, Some(ext), 0)?
+            } else {
+                Self::data_noqueue(&mut self.write, channel, &buf0, Some(ext), 0)?
+            };
             if buf_len < buf0.len() {
                 channel.pending_data.push_back((buf0, Some(ext), buf_len))
             }
@@ -627,7 +751,8 @@ mod tests {
     use super::{Encrypted, EncryptedState, Exchange};
     use crate::compression::{Compression, Decompress};
     use crate::kex::{KEXES, NONE};
-    use crate::{ChannelId, ChannelParams, CryptoVec, mac, msg};
+    use crate::sshbuffer::PacketWriter;
+    use crate::{ChannelId, ChannelParams, CryptoVec, Limits, mac, msg};
 
     fn test_encrypted() -> Encrypted {
         Encrypted {
@@ -684,6 +809,25 @@ mod tests {
         }
 
         packet_types
+    }
+
+    fn clear_packet_types(buf: &[u8]) -> Vec<u8> {
+        let mut packet_types = Vec::new();
+        let mut cursor = 0;
+
+        while cursor < buf.len() {
+            let packet_len = BigEndian::read_u32(&buf[cursor..cursor + 4]) as usize;
+            packet_types.push(buf[cursor + 5]);
+            cursor += 4 + packet_len;
+        }
+
+        packet_types
+    }
+
+    fn test_ready_channel(sender_channel: ChannelId, recipient_channel: u32) -> ChannelParams {
+        let mut channel = test_channel(sender_channel, recipient_channel, false, false);
+        channel.pending_data.clear();
+        channel
     }
 
     fn test_channel_windowed(
@@ -908,5 +1052,204 @@ mod tests {
         assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
         assert_eq!(channel.pending_data.back().unwrap().1, Some(ext));
         assert!(encrypted.write.is_empty());
+    }
+
+    #[test]
+    fn data_direct_matches_staged_channel_data() {
+        let channel_id = ChannelId(20);
+        let payload = Bytes::from_static(b"direct channel data");
+        let mut staged = test_encrypted();
+        let mut direct = test_encrypted();
+        staged
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 42));
+        direct
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 42));
+
+        let mut staged_writer = PacketWriter::clear();
+        staged.data(channel_id, payload.clone(), false).unwrap();
+        staged
+            .flush(&Limits::default(), &mut staged_writer)
+            .unwrap();
+
+        let mut direct_writer = PacketWriter::clear();
+        direct
+            .data_with_writer(&mut direct_writer, channel_id, payload, false)
+            .unwrap();
+
+        assert_eq!(
+            direct_writer.buffer().buffer,
+            staged_writer.buffer().buffer
+        );
+        assert_eq!(
+            direct.channels[&channel_id].recipient_window_size,
+            staged.channels[&channel_id].recipient_window_size
+        );
+        assert!(direct.channels[&channel_id].pending_data.is_empty());
+    }
+
+    #[test]
+    fn extended_data_direct_matches_staged_channel_data() {
+        let channel_id = ChannelId(21);
+        let payload = Bytes::from_static(b"direct extended channel data");
+        let mut staged = test_encrypted();
+        let mut direct = test_encrypted();
+        staged
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 43));
+        direct
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 43));
+
+        let mut staged_writer = PacketWriter::clear();
+        staged
+            .extended_data(channel_id, 1, payload.clone(), false)
+            .unwrap();
+        staged
+            .flush(&Limits::default(), &mut staged_writer)
+            .unwrap();
+
+        let mut direct_writer = PacketWriter::clear();
+        direct
+            .extended_data_with_writer(&mut direct_writer, channel_id, 1, payload, false)
+            .unwrap();
+
+        assert_eq!(
+            direct_writer.buffer().buffer,
+            staged_writer.buffer().buffer
+        );
+        assert_eq!(
+            direct.channels[&channel_id].recipient_window_size,
+            staged.channels[&channel_id].recipient_window_size
+        );
+        assert!(direct.channels[&channel_id].pending_data.is_empty());
+    }
+
+    #[test]
+    fn data_direct_is_disabled_when_write_queue_nonempty() {
+        let channel_id = ChannelId(22);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 44));
+        push_packet!(encrypted.write, encrypted.write.push(msg::REQUEST_SUCCESS));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .data_with_writer(&mut writer, channel_id, Bytes::from_static(b"new"), false)
+            .unwrap();
+
+        assert!(writer.buffer().buffer.is_empty());
+        assert_eq!(
+            packet_types(&encrypted.write),
+            vec![msg::REQUEST_SUCCESS, msg::CHANNEL_DATA]
+        );
+
+        encrypted.flush(&Limits::default(), &mut writer).unwrap();
+        assert_eq!(
+            clear_packet_types(&writer.buffer().buffer),
+            vec![msg::REQUEST_SUCCESS, msg::CHANNEL_DATA]
+        );
+    }
+
+    #[test]
+    fn data_staged_large_payload_when_write_queue_nonempty_preserves_order_and_chunks() {
+        let channel_id = ChannelId(26);
+        let mut encrypted = test_encrypted();
+        let mut channel = test_ready_channel(channel_id, 48);
+        channel.recipient_window_size = 256 * 1024;
+        channel.recipient_maximum_packet_size = 32 * 1024;
+        encrypted.channels.insert(channel_id, channel);
+        push_packet!(encrypted.write, encrypted.write.push(msg::REQUEST_SUCCESS));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .data_with_writer(
+                &mut writer,
+                channel_id,
+                Bytes::from(vec![0x5a; 256 * 1024]),
+                false,
+            )
+            .unwrap();
+
+        assert!(writer.buffer().buffer.is_empty());
+        let packet_types = packet_types(&encrypted.write);
+        assert_eq!(packet_types.first(), Some(&msg::REQUEST_SUCCESS));
+        assert_eq!(packet_types.len(), 9);
+        assert!(
+            packet_types
+                .iter()
+                .skip(1)
+                .all(|&msg_type| msg_type == msg::CHANNEL_DATA)
+        );
+        assert!(encrypted.channels[&channel_id].pending_data.is_empty());
+        assert_eq!(encrypted.channels[&channel_id].recipient_window_size, 0);
+    }
+
+    #[test]
+    fn data_direct_is_disabled_while_rekeying() {
+        let channel_id = ChannelId(23);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_ready_channel(channel_id, 45));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .data_with_writer(&mut writer, channel_id, Bytes::from_static(b"new"), true)
+            .unwrap();
+
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(channel.pending_data.len(), 1);
+        assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
+        assert_eq!(channel.pending_data.back().unwrap().1, None);
+        assert!(encrypted.write.is_empty());
+        assert!(writer.buffer().buffer.is_empty());
+    }
+
+    #[test]
+    fn data_direct_queues_remainder_when_window_is_partial() {
+        let channel_id = ChannelId(24);
+        let payload = Bytes::from_static(b"abcdef");
+        let mut encrypted = test_encrypted();
+        let mut channel = test_ready_channel(channel_id, 46);
+        channel.recipient_window_size = 3;
+        encrypted.channels.insert(channel_id, channel);
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .data_with_writer(&mut writer, channel_id, payload.clone(), false)
+            .unwrap();
+
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(clear_packet_types(&writer.buffer().buffer), vec![msg::CHANNEL_DATA]);
+        assert_eq!(channel.recipient_window_size, 0);
+        assert_eq!(channel.pending_data.len(), 1);
+        let pending = channel.pending_data.back().unwrap();
+        assert_eq!(pending.0, payload);
+        assert_eq!(pending.1, None);
+        assert_eq!(pending.2, 3);
+    }
+
+    #[test]
+    fn data_direct_disabled_behind_existing_pending_data() {
+        let channel_id = ChannelId(25);
+        let mut encrypted = test_encrypted();
+        encrypted
+            .channels
+            .insert(channel_id, test_channel(channel_id, 47, false, false));
+
+        let mut writer = PacketWriter::clear();
+        encrypted
+            .data_with_writer(&mut writer, channel_id, Bytes::from_static(b"new"), false)
+            .unwrap();
+
+        let channel = &encrypted.channels[&channel_id];
+        assert_eq!(channel.pending_data.len(), 2);
+        assert_eq!(channel.pending_data.front().unwrap().0.as_ref(), b"hello");
+        assert_eq!(channel.pending_data.back().unwrap().0.as_ref(), b"new");
+        assert!(encrypted.write.is_empty());
+        assert!(writer.buffer().buffer.is_empty());
     }
 }

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -17,6 +17,7 @@ use core::fmt;
 use std::borrow::Cow;
 use std::num::Wrapping;
 
+use bytes::Bytes;
 use super::cipher::SealingKey;
 use compression::Compress;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -109,6 +110,7 @@ pub(crate) struct IncomingSshPacket {
 pub(crate) struct PacketWriter {
     cipher: Box<dyn SealingKey + Send>,
     compress: Compress,
+    packet_buffer: Vec<u8>,
     compress_buffer: Vec<u8>,
     write_buffer: SSHBuffer,
 }
@@ -128,8 +130,24 @@ impl PacketWriter {
         Self {
             cipher,
             compress,
+            packet_buffer: Vec::new(),
             compress_buffer: Vec::new(),
             write_buffer: SSHBuffer::new(),
+        }
+    }
+
+    fn prepare_packet<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
+        &mut self,
+        f: F,
+    ) -> Result<Vec<u8>, Error> {
+        let mut buf = std::mem::take(&mut self.packet_buffer);
+        buf.clear();
+        match f(&mut buf) {
+            Ok(()) => Ok(buf),
+            Err(err) => {
+                self.packet_buffer = buf;
+                Err(err)
+            }
         }
     }
 
@@ -142,16 +160,26 @@ impl PacketWriter {
         Ok(())
     }
 
-    /// Sends and returns the packet contents.
-    /// Packet buffer is not secret — use Vec<u8> for performance.
+    /// Sends a packet using the reusable plaintext packet buffer.
+    pub fn write_packet<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
+        &mut self,
+        f: F,
+    ) -> Result<(), Error> {
+        let buf = self.prepare_packet(f)?;
+        let result = self.packet_raw(&buf);
+        self.packet_buffer = buf;
+        result
+    }
+
+    /// Sends and returns the packet contents for callers that need to retain
+    /// the plaintext packet after it has been queued for encryption.
     pub fn packet<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
         &mut self,
         f: F,
-    ) -> Result<Vec<u8>, Error> {
-        let mut buf = Vec::new();
-        f(&mut buf)?;
+    ) -> Result<Bytes, Error> {
+        let buf = self.prepare_packet(f)?;
         self.packet_raw(&buf)?;
-        Ok(buf)
+        Ok(buf.into())
     }
 
     pub fn buffer(&mut self) -> &mut SSHBuffer {

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -18,6 +18,7 @@ use std::borrow::Cow;
 use std::num::Wrapping;
 
 use bytes::{Bytes, BytesMut};
+use log::debug;
 use ssh_encoding::Writer;
 use super::cipher::SealingKey;
 use compression::Compress;
@@ -73,9 +74,10 @@ fn test_ssh_id() {
 }
 
 #[test]
-fn test_write_packet_retains_reusable_buffer_for_cold_path_packets() {
+fn test_write_packet_leaves_reusable_buffer_for_cold_path_packets() {
     let mut writer = PacketWriter::clear();
     let large_len = 128 * 1024;
+    let packet_buffer_capacity = writer.packet_buffer.capacity();
 
     writer
         .write_packet(|buf| {
@@ -83,7 +85,7 @@ fn test_write_packet_retains_reusable_buffer_for_cold_path_packets() {
             Ok(())
         })
         .unwrap();
-    assert!(writer.packet_buffer.capacity() >= large_len);
+    assert_eq!(writer.packet_buffer.capacity(), packet_buffer_capacity);
 }
 
 #[test]
@@ -369,6 +371,8 @@ impl Debug for PacketWriter {
 }
 
 impl PacketWriter {
+    // SSH packet prefix = packet_length (cipher::PACKET_LENGTH_LEN bytes)
+    // + padding_length (1 byte).
     const PACKET_PREFIX_LEN: usize = cipher::PACKET_LENGTH_LEN + 1;
 
     pub fn clear() -> Self {
@@ -428,7 +432,6 @@ impl PacketWriter {
                     debug!("> msg type {message_type:?}, len {payload_len}");
                 }
 
-                self.packet_buffer.reserve(payload_len);
                 self.cipher
                     .finish_packet(offset, payload_len, &mut self.write_buffer);
                 Ok(())

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -71,6 +71,30 @@ fn test_ssh_id() {
     );
 }
 
+#[test]
+fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
+    let mut writer = PacketWriter::clear();
+    let large_len = 128 * 1024;
+
+    writer
+        .write_packet(|buf| {
+            buf.resize(large_len, 0x5a);
+            Ok(())
+        })
+        .unwrap();
+    assert!(writer.packet_buffer.capacity() >= large_len);
+
+    let retained = writer
+        .packet(|buf| {
+            buf.extend_from_slice(b"abc");
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(&retained[..], b"abc");
+    assert!(writer.packet_buffer.capacity() >= large_len);
+}
+
 /// SSH packet read/write buffer. Uses Vec<u8> (not CryptoVec/mlocked) because
 /// packet data is not secret material.
 #[derive(Debug, Default)]

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -87,6 +87,31 @@ fn test_write_packet_retains_reusable_buffer_for_cold_path_packets() {
 }
 
 #[test]
+fn reserve_cleartext_packet_output_reserves_output_capacity() {
+    let mut writer = PacketWriter::clear();
+    let payload_bytes = 4096;
+    let packet_count = 4;
+
+    writer.reserve_cleartext_packet_output(payload_bytes, packet_count);
+
+    let expected = payload_bytes
+        + packet_count * (PacketWriter::PACKET_PREFIX_LEN + writer.cipher.tag_len() + 32);
+    assert!(writer.write_buffer.buffer.capacity() >= expected);
+    assert!(writer.write_buffer.buffer.is_empty());
+}
+
+#[cfg(feature = "flate2")]
+#[test]
+fn reserve_cleartext_packet_output_ignores_compressed_writer() {
+    let mut writer = PacketWriter::new(Box::new(cipher::clear::Key {}), zlib_compress());
+    let capacity = writer.write_buffer.buffer.capacity();
+
+    writer.reserve_cleartext_packet_output(4096, 4);
+
+    assert_eq!(writer.write_buffer.buffer.capacity(), capacity);
+}
+
+#[test]
 fn test_packet_returns_retained_bytes() {
     let mut writer = PacketWriter::clear();
     let retained = writer
@@ -472,6 +497,23 @@ impl PacketWriter {
         let result = self.packet_raw(&buf);
         self.packet_buffer = buf;
         result
+    }
+
+    pub(crate) fn reserve_cleartext_packet_output(
+        &mut self,
+        payload_bytes: usize,
+        packet_count: usize,
+    ) {
+        if !matches!(&self.compress, Compress::None) {
+            return;
+        }
+
+        // Padding is cipher-dependent and rounded to the cipher block size.
+        // Reserving a small fixed margin avoids repeated output-buffer growth
+        // without coupling callers to individual cipher padding formulas.
+        let per_packet_margin = Self::PACKET_PREFIX_LEN + self.cipher.tag_len() + 32;
+        let additional = payload_bytes.saturating_add(packet_count.saturating_mul(per_packet_margin));
+        self.write_buffer.buffer.reserve(additional);
     }
 
     /// Sends and returns the packet contents for callers that need to retain

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -344,6 +344,13 @@ impl PacketWriter {
     }
 
     /// Sends a packet using the reusable plaintext packet buffer.
+    ///
+    /// The closure must append only the packet payload bytes. It must not
+    /// modify or truncate any existing contents in the provided buffer.
+    /// When compression is disabled, the buffer may already contain queued
+    /// packets and the reserved 5-byte packet header prefix for the packet
+    /// being built, so callers must only write new payload bytes starting at
+    /// the current end of the buffer.
     pub fn write_packet<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
         &mut self,
         f: F,

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -202,8 +202,9 @@ impl PacketWriter {
         f: F,
     ) -> Result<Bytes, Error> {
         let buf = self.prepare_packet(f)?;
-        self.packet_raw(&buf)?;
-        Ok(buf.into())
+        let result = self.packet_raw(&buf).map(|()| Bytes::copy_from_slice(&buf));
+        self.packet_buffer = buf;
+        result
     }
 
     pub fn buffer(&mut self) -> &mut SSHBuffer {

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -17,7 +17,8 @@ use core::fmt;
 use std::borrow::Cow;
 use std::num::Wrapping;
 
-use bytes::Bytes;
+use bytes::{Bytes, BytesMut};
+use ssh_encoding::Writer;
 use super::cipher::SealingKey;
 use compression::Compress;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
@@ -72,7 +73,7 @@ fn test_ssh_id() {
 }
 
 #[test]
-fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
+fn test_write_packet_retains_reusable_buffer_for_cold_path_packets() {
     let mut writer = PacketWriter::clear();
     let large_len = 128 * 1024;
 
@@ -83,7 +84,11 @@ fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
         })
         .unwrap();
     assert!(writer.packet_buffer.capacity() >= large_len);
+}
 
+#[test]
+fn test_packet_returns_retained_bytes() {
+    let mut writer = PacketWriter::clear();
     let retained = writer
         .packet(|buf| {
             buf.extend_from_slice(b"abc");
@@ -92,7 +97,46 @@ fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
         .unwrap();
 
     assert_eq!(&retained[..], b"abc");
-    assert!(writer.packet_buffer.capacity() >= large_len);
+}
+
+#[test]
+fn packet_bytes_returns_retained_bytes() {
+    let mut writer = PacketWriter::clear();
+    let retained = writer
+        .packet_bytes(|buf| {
+            buf.extend_from_slice(b"abc");
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(&retained[..], b"abc");
+}
+
+#[test]
+fn packet_bytes_matches_packet_output() {
+    let payload = b"abcdefghijklmno".to_vec();
+
+    let mut packet_writer = PacketWriter::clear();
+    let packet_retained = packet_writer
+        .packet(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+    let packet_buffer = packet_writer.buffer().buffer.clone();
+    let packet_bytes = packet_writer.buffer().bytes;
+
+    let mut packet_bytes_writer = PacketWriter::clear();
+    let bytes_retained = packet_bytes_writer
+        .packet_bytes(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(packet_retained, bytes_retained);
+    assert_eq!(packet_bytes_writer.buffer().buffer, packet_buffer);
+    assert_eq!(packet_bytes_writer.buffer().bytes, packet_bytes);
 }
 
 #[test]
@@ -184,6 +228,35 @@ fn test_packet_retains_plaintext_for_compressed_packets() {
     assert_eq!(&retained[..], &payload);
 }
 
+#[cfg(feature = "flate2")]
+#[test]
+fn packet_bytes_compressed_matches_packet_output() {
+    let payload = b"abcdefghijklmnoabcdefghijklmno".to_vec();
+
+    let mut packet_writer = PacketWriter::new(Box::new(cipher::clear::Key {}), zlib_compress());
+    let packet_retained = packet_writer
+        .packet(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+    let packet_buffer = packet_writer.buffer().buffer.clone();
+    let packet_bytes = packet_writer.buffer().bytes;
+
+    let mut packet_bytes_writer =
+        PacketWriter::new(Box::new(cipher::clear::Key {}), zlib_compress());
+    let bytes_retained = packet_bytes_writer
+        .packet_bytes(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(packet_retained, bytes_retained);
+    assert_eq!(packet_bytes_writer.buffer().buffer, packet_buffer);
+    assert_eq!(packet_bytes_writer.buffer().bytes, packet_bytes);
+}
+
 /// SSH packet read/write buffer. Uses Vec<u8> (not CryptoVec/mlocked) because
 /// packet data is not secret material.
 #[derive(Debug, Default)]
@@ -208,6 +281,43 @@ impl SSHBuffer {
 
     pub fn send_ssh_id(&mut self, id: &SshId) {
         id.write(&mut self.buffer);
+    }
+}
+
+pub(crate) struct PacketBytesWriter {
+    buffer: BytesMut,
+}
+
+impl Writer for PacketBytesWriter {
+    fn write(&mut self, bytes: &[u8]) -> ssh_encoding::Result<()> {
+        self.buffer.extend_from_slice(bytes);
+        Ok(())
+    }
+}
+
+impl PacketBytesWriter {
+    #[allow(dead_code)]
+    pub(crate) fn push(&mut self, byte: u8) {
+        self.buffer.extend_from_slice(&[byte]);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn extend_from_slice(&mut self, bytes: &[u8]) {
+        self.buffer.extend_from_slice(bytes);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn len(&self) -> usize {
+        self.buffer.len()
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn is_empty(&self) -> bool {
+        self.buffer.is_empty()
+    }
+
+    fn freeze(self) -> Bytes {
+        self.buffer.freeze()
     }
 }
 
@@ -366,14 +476,30 @@ impl PacketWriter {
 
     /// Sends and returns the packet contents for callers that need to retain
     /// the plaintext packet after it has been queued for encryption.
+    #[allow(dead_code)]
     pub fn packet<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
         &mut self,
         f: F,
     ) -> Result<Bytes, Error> {
         let buf = self.prepare_packet(f)?;
-        let result = self.packet_raw(&buf).map(|()| Bytes::copy_from_slice(&buf));
-        self.packet_buffer = buf;
-        result
+        if let Err(err) = self.packet_raw(&buf) {
+            self.packet_buffer = buf;
+            return Err(err);
+        }
+        Ok(Bytes::from(buf))
+    }
+
+    pub(crate) fn packet_bytes<F>(&mut self, f: F) -> Result<Bytes, Error>
+    where
+        F: FnOnce(&mut PacketBytesWriter) -> Result<(), Error>,
+    {
+        let mut buf = PacketBytesWriter {
+            buffer: BytesMut::new(),
+        };
+        f(&mut buf)?;
+        let packet = buf.freeze();
+        self.packet_raw(packet.as_ref())?;
+        Ok(packet)
     }
 
     pub fn buffer(&mut self) -> &mut SSHBuffer {

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -78,7 +78,7 @@ fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
 
     writer
         .write_packet(|buf| {
-            buf.resize(large_len, 0x5a);
+            buf.resize(buf.len() + large_len, 0x5a);
             Ok(())
         })
         .unwrap();
@@ -93,6 +93,95 @@ fn test_packet_retains_reusable_buffer_for_cold_path_packets() {
 
     assert_eq!(&retained[..], b"abc");
     assert!(writer.packet_buffer.capacity() >= large_len);
+}
+
+#[test]
+fn test_write_packet_matches_clear_cipher_write_output() {
+    let payload = b"abcdefghijklmno".to_vec();
+
+    let mut expected = SSHBuffer::new();
+    let mut clear = cipher::clear::Key {};
+    clear.write(&payload, &mut expected);
+
+    let mut writer = PacketWriter::clear();
+    writer
+        .write_packet(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(writer.buffer().buffer, expected.buffer);
+    assert_eq!(writer.buffer().bytes, payload.len());
+    assert_eq!(writer.buffer().seqn, Wrapping(1));
+}
+
+#[test]
+fn test_write_packet_restores_output_buffer_on_error() {
+    let mut writer = PacketWriter::clear();
+    writer
+        .write_packet(|buf| {
+            buf.extend_from_slice(b"ok");
+            Ok(())
+        })
+        .unwrap();
+    let before = writer.buffer().buffer.clone();
+
+    let err = writer.write_packet(|buf| {
+        buf.extend_from_slice(b"partial");
+        Err(Error::Inconsistent)
+    });
+
+    assert!(matches!(err, Err(Error::Inconsistent)));
+    assert_eq!(writer.buffer().buffer, before);
+}
+
+#[cfg(all(test, feature = "flate2"))]
+fn zlib_compress() -> Compress {
+    let mut compress = Compress::None;
+    compression::Compression::Zlib.init_compress(&mut compress);
+    compress
+}
+
+#[cfg(feature = "flate2")]
+#[test]
+fn test_write_packet_compressed_matches_clear_cipher_output() {
+    let payload = b"abcdefghijklmnoabcdefghijklmno".to_vec();
+
+    let mut expected = SSHBuffer::new();
+    let mut clear = cipher::clear::Key {};
+    let mut compress = zlib_compress();
+    let mut compressed = Vec::new();
+    let packet = compress.compress(&payload, &mut compressed).unwrap();
+    clear.write(packet, &mut expected);
+
+    let mut writer = PacketWriter::new(Box::new(cipher::clear::Key {}), zlib_compress());
+    writer
+        .write_packet(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(writer.buffer().buffer, expected.buffer);
+    assert_eq!(writer.buffer().bytes, packet.len());
+    assert_eq!(writer.buffer().seqn, Wrapping(1));
+}
+
+#[cfg(feature = "flate2")]
+#[test]
+fn test_packet_retains_plaintext_for_compressed_packets() {
+    let payload = b"abcdefghijklmnoabcdefghijklmno".to_vec();
+
+    let mut writer = PacketWriter::new(Box::new(cipher::clear::Key {}), zlib_compress());
+    let retained = writer
+        .packet(|buf| {
+            buf.extend_from_slice(&payload);
+            Ok(())
+        })
+        .unwrap();
+
+    assert_eq!(&retained[..], &payload);
 }
 
 /// SSH packet read/write buffer. Uses Vec<u8> (not CryptoVec/mlocked) because
@@ -135,7 +224,6 @@ pub(crate) struct PacketWriter {
     cipher: Box<dyn SealingKey + Send>,
     compress: Compress,
     packet_buffer: Vec<u8>,
-    compress_buffer: Vec<u8>,
     write_buffer: SSHBuffer,
 }
 
@@ -146,6 +234,8 @@ impl Debug for PacketWriter {
 }
 
 impl PacketWriter {
+    const PACKET_PREFIX_LEN: usize = cipher::PACKET_LENGTH_LEN + 1;
+
     pub fn clear() -> Self {
         Self::new(Box::new(cipher::clear::Key {}), Compress::None)
     }
@@ -155,7 +245,6 @@ impl PacketWriter {
             cipher,
             compress,
             packet_buffer: Vec::new(),
-            compress_buffer: Vec::new(),
             write_buffer: SSHBuffer::new(),
         }
     }
@@ -175,11 +264,81 @@ impl PacketWriter {
         }
     }
 
+    fn write_packet_in_place<F: FnOnce(&mut Vec<u8>) -> Result<(), Error>>(
+        &mut self,
+        f: F,
+    ) -> Result<(), Error> {
+        self.write_payload_into_output(|buffer, payload_start| {
+            f(buffer)?;
+            Ok(buffer.len() - payload_start)
+        })
+    }
+
+    fn write_payload_into_output<F>(&mut self, f: F) -> Result<(), Error>
+    where
+        F: FnOnce(&mut Vec<u8>, usize) -> Result<usize, Error>,
+    {
+        let offset = self.write_buffer.buffer.len();
+        let payload_start = offset + Self::PACKET_PREFIX_LEN;
+
+        self.write_buffer.buffer.resize(payload_start, 0);
+        match f(&mut self.write_buffer.buffer, payload_start) {
+            Ok(payload_len) => {
+                if payload_len == 0 {
+                    self.write_buffer.buffer.truncate(offset);
+                    return Ok(());
+                }
+
+                if let Some(message_type) = self.write_buffer.buffer.get(payload_start) {
+                    debug!("> msg type {message_type:?}, len {payload_len}");
+                }
+
+                self.packet_buffer.reserve(payload_len);
+                self.cipher
+                    .finish_packet(offset, payload_len, &mut self.write_buffer);
+                Ok(())
+            }
+            Err(err) => {
+                self.write_buffer.buffer.truncate(offset);
+                Err(err)
+            }
+        }
+    }
+
+    fn write_compressed_payload_into_output(&mut self, buf: &[u8]) -> Result<(), Error> {
+        let offset = self.write_buffer.buffer.len();
+        let payload_start = offset + Self::PACKET_PREFIX_LEN;
+
+        self.write_buffer.buffer.resize(payload_start, 0);
+        match self
+            .compress
+            .compress_into(buf, &mut self.write_buffer.buffer, payload_start)
+        {
+            Ok(payload_len) => {
+                if payload_len == 0 {
+                    self.write_buffer.buffer.truncate(offset);
+                    return Ok(());
+                }
+
+                self.cipher
+                    .finish_packet(offset, payload_len, &mut self.write_buffer);
+                Ok(())
+            }
+            Err(err) => {
+                self.write_buffer.buffer.truncate(offset);
+                Err(err)
+            }
+        }
+    }
+
     pub fn packet_raw(&mut self, buf: &[u8]) -> Result<(), Error> {
         if let Some(message_type) = buf.first() {
             debug!("> msg type {message_type:?}, len {}", buf.len());
-            let packet = self.compress.compress(buf, &mut self.compress_buffer)?;
-            self.cipher.write(packet, &mut self.write_buffer);
+            if matches!(&self.compress, Compress::None) {
+                self.cipher.write(buf, &mut self.write_buffer);
+            } else {
+                self.write_compressed_payload_into_output(buf)?;
+            }
         }
         Ok(())
     }
@@ -189,6 +348,9 @@ impl PacketWriter {
         &mut self,
         f: F,
     ) -> Result<(), Error> {
+        if matches!(&self.compress, Compress::None) {
+            return self.write_packet_in_place(f);
+        }
         let buf = self.prepare_packet(f)?;
         let result = self.packet_raw(&buf);
         self.packet_buffer = buf;

--- a/russh/tests/test_max_channel_packet_size.rs
+++ b/russh/tests/test_max_channel_packet_size.rs
@@ -11,9 +11,21 @@ use tokio::io::{AsyncWrite, AsyncWriteExt};
 const MAX_CHANNEL_PACKET_SIZE: u32 = 256 * 1024;
 const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const STDERR_EXTENDED_DATA_TYPE: u32 = 1;
+#[cfg(feature = "flate2")]
+const ZLIB_ONLY: &[compression::Name] = &[compression::ZLIB];
 
 #[tokio::test]
 async fn test_aes256_gcm_allows_full_256k_channel_packet() {
+    run_max_channel_packet_size_test(None).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "flate2")]
+async fn test_aes256_gcm_with_zlib_allows_full_256k_channel_packet() {
+    run_max_channel_packet_size_test(Some(ZLIB_ONLY)).await;
+}
+
+async fn run_max_channel_packet_size_test(compression: Option<&'static [compression::Name]>) {
     let _ = env_logger::try_init();
 
     let client_key = PrivateKey::random(&mut rand::rng(), ssh_key::Algorithm::Ed25519).unwrap();
@@ -29,6 +41,9 @@ async fn test_aes256_gcm_allows_full_256k_channel_packet() {
     server_config.preferred = {
         let mut preferred = Preferred::default();
         preferred.cipher = Cow::Borrowed(&[cipher::AES_256_GCM]);
+        if let Some(compression) = compression {
+            preferred.compression = Cow::Borrowed(compression);
+        }
         preferred
     };
 
@@ -49,6 +64,9 @@ async fn test_aes256_gcm_allows_full_256k_channel_packet() {
     client_config.preferred = {
         let mut preferred = Preferred::default();
         preferred.cipher = Cow::Borrowed(&[cipher::AES_256_GCM]);
+        if let Some(compression) = compression {
+            preferred.compression = Cow::Borrowed(compression);
+        }
         preferred
     };
 


### PR DESCRIPTION
## Summary

This PR reduces write-path copying in `russh` by moving more packet assembly directly into `PacketWriter` and by sending owned channel payloads as `Bytes` where ordering allows.

For channel data, the new fast path writes `Bytes` payloads straight into `PacketWriter` instead of first staging plaintext into `Encrypted.write`. That path is used only when the channel is confirmed, no rekey is in progress, there is no older pending data for that channel, and the session write queue is empty. If any of those conditions are not met, behavior falls back to the existing queued path.

The same direct-writer path is now used when replaying pending channel data after a window adjustment or after rekey completion, again only when ordering permits. This keeps the existing ordering guarantees while avoiding the extra staging copy on the replay path too.

## API additions

This also adds owned-`Bytes` channel send helpers:

- `Channel::data_bytes`
- `Channel::extended_data_bytes`
- `ChannelWriteHalf::data_bytes`
- `ChannelWriteHalf::extended_data_bytes`

These helpers split payloads by writable window and max packet size using `Bytes::slice(...)`, so callers that already own a `Bytes` buffer can enqueue channel data without the extra copy inherent in the `AsyncWrite<&[u8]>` path.

## Packet writer changes

To support the direct path, `PacketWriter` is refactored so it can assemble and seal packets directly into its output buffer when compression is disabled, while still keeping a reusable plaintext packet buffer for retained-packet and compressed cases. The compressed path is also tightened so compressed output can be written directly into the final output buffer.

Retained KEXINIT-style packets are now kept as `Bytes`, and the stored client/server KEXINIT payloads in `Exchange` use `Bytes` as well.

## Hardening and validation

This PR also hardens channel write sizing by returning `Error::Inconsistent` when a peer advertises a zero max packet size instead of panicking.

Coverage was expanded around:

- direct channel-data writes
- pending-data replay through `PacketWriter`
- rekey replay behavior
- retained packet handling
- zlib + max-channel-packet-size behavior

## Wall-Clock Measurements

Temporary harnesses, not committed. Base is updated `main` at `c31cbc9`.

Numbers below are median-of-5 runs from the same local harness.

| case | main path | branch path | main median ns/op | branch median ns/op | faster by |
|---|---|---|---:|---:|---:|
| channel data, 32 KiB | current `Encrypted.write` staging | direct `Bytes` -> `PacketWriter` | 1,038.75 | 649.63 | 37.5% |
| channel data, 256 KiB | current `Encrypted.write` staging | direct `Bytes` -> `PacketWriter` | 10,418.58 | 5,690.90 | 45.4% |
| pending replay, 32 KiB | replay into `Encrypted.write` | replay into `PacketWriter` | 945.84 | 520.06 | 45.0% |
| pending replay, 256 KiB | replay into `Encrypted.write` | replay into `PacketWriter` | 9,649.69 | 4,508.97 | 53.3% |
| channel API, 32 KiB | `AsyncWrite<&[u8]>` copy path | owned `Bytes` API | 657.25 | 135.53 | 79.4% |
| channel API, 256 KiB | `AsyncWrite<&[u8]>` copy path | owned `Bytes` API | 6,256.34 | 953.55 | 84.8% |

## IAI/Callgrind Measurements

Same temporary harness. Instruction counts:

| case | main Ir | branch Ir | reduction |
|---|---:|---:|---:|
| channel data, 32 KiB | 82,811 | 48,104 | 41.9% |
| channel data, 256 KiB | 678,528 | 280,143 | 58.7% |
| pending replay, 32 KiB | 83,414 | 48,609 | 41.7% |
| pending replay, 256 KiB | 679,144 | 280,730 | 58.7% |

Retained packet construction is effectively flat by IAI: `67,817 Ir` on main vs `67,931 Ir` here for the 32 KiB retained packet case.


