### PR TITLE
Add GitArena to adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ This is a fork of [Thrussh](https://nest.pijul.com/pijul/thrussh) by Pierre-Éti
   * Uses russh::client for SSH transport, authentication, and interactive PTY sessions.
 * [Yazi](https://github.com/sxyazi/yazi) - Blazing fast terminal file manager written in Rust, based on async I/O.
   * Uses `russh::client` to implement an async SFTP provider for remote file management.
+* [GitArena](https://github.com/mellowagain/gitarena) - Software development platform with built-in vcs, issue tracking and code review.
+  * Uses `russh::server` to allow Git operations over SSH. 
 
 ## Contributors ✨
 


### PR DESCRIPTION
I recently implemented Git-over-SSH support and it was enabled thanks to this amazing crate, thanks a lot!