### PR TITLE
fix(deps): migrate to stable pkcs5 / pkcs8 / ed25519 and loosen prerelease pins (extends #697)

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -53,9 +53,9 @@ delegate.workspace = true
 digest.workspace = true
 der = "0.8"
 des = { version = "0.8.1", optional = true }
-ecdsa = "0.17.0-rc.18"
-ed25519-dalek = { version = "3.0.0-pre.7", features = ["alloc", "rand_core", "pkcs8"] }
-elliptic-curve = { version = "0.14.0-rc.32", features = ["ecdh"] }
+ecdsa = "=0.17.0-rc.18"
+ed25519-dalek = { version = "=3.0.0-pre.7", features = ["alloc", "rand_core", "pkcs8"] }
+elliptic-curve = { version = "=0.14.0-rc.32", features = ["ecdh"] }
 enum_dispatch = "0.3.13"
 flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
@@ -78,9 +78,9 @@ module-lattice = "0.2"
 num-bigint = { package = "internal-russh-num-bigint", version = "=0.5.0", features = ["rand_0_10"] }
 num_bigint_0_4 = { package = "num-bigint", version = "0.4.6" }
 # num-integer = "0.1"
-p256 = { version = "0.14.0-rc.9", features = ["ecdh"] }
-p384 = { version = "0.14.0-rc.9", features = ["ecdh"] }
-p521 = { version = "0.14.0-rc.9", features = ["ecdh"] }
+p256 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
+p384 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
+p521 = { version = "=0.14.0-rc.9", features = ["ecdh"] }
 pbkdf2 = "0.12"
 pbkdf2_0_13 = { package = "pbkdf2", version = "0.13.0" }
 pkcs1 = { version = "=0.8.0-rc.4", optional = true }
@@ -90,7 +90,7 @@ polyval = "0.7.1" # only pinned due to a cargo-minimal-versions failure in 0.7.0
 rand_core = { version = "0.10.0" }
 rand.workspace = true
 ring = { version = "0.17.14", optional = true }
-rsa = { version = "0.10.0-rc.18", optional = true }
+rsa = { version = "=0.10.0-rc.18", optional = true }
 russh-cryptovec = { version = "0.60.3", path = "../cryptovec", features = [
   "ssh-encoding",
 ] }

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -47,15 +47,15 @@ cipher = "0.5.1" # only pinned due to a cargo-minimal-versions failure in 0.5.0
 ctr = "0.9"
 ctr_0_10 = { package = "ctr", version = "0.10.0" }
 curve25519-dalek = "=5.0.0-pre.6"
-crypto-bigint = { version = "=0.7.0-rc.28", features = ["alloc"] }
+crypto-bigint = { version = "0.7.3", features = ["alloc"] }
 data-encoding = "2.3"
 delegate.workspace = true
 digest.workspace = true
 der = "0.8"
 des = { version = "0.8.1", optional = true }
-ecdsa = "=0.17.0-rc.16"
-ed25519-dalek = { version = "=3.0.0-pre.6", features = ["alloc", "rand_core", "pkcs8"] }
-elliptic-curve = { version = "=0.14.0-rc.28", features = ["ecdh"] }
+ecdsa = "0.17.0-rc.18"
+ed25519-dalek = { version = "3.0.0-pre.7", features = ["alloc", "rand_core", "pkcs8"] }
+elliptic-curve = { version = "0.14.0-rc.32", features = ["ecdh"] }
 enum_dispatch = "0.3.13"
 flate2 = { version = "1.0.15", optional = true }
 futures.workspace = true
@@ -78,19 +78,19 @@ module-lattice = "0.2"
 num-bigint = { package = "internal-russh-num-bigint", version = "=0.5.0", features = ["rand_0_10"] }
 num_bigint_0_4 = { package = "num-bigint", version = "0.4.6" }
 # num-integer = "0.1"
-p256 = { version = "=0.14.0-rc.7", features = ["ecdh"] }
-p384 = { version = "=0.14.0-rc.7", features = ["ecdh"] }
-p521 = { version = "=0.14.0-rc.7", features = ["ecdh"] }
+p256 = { version = "0.14.0-rc.9", features = ["ecdh"] }
+p384 = { version = "0.14.0-rc.9", features = ["ecdh"] }
+p521 = { version = "0.14.0-rc.9", features = ["ecdh"] }
 pbkdf2 = "0.12"
 pbkdf2_0_13 = { package = "pbkdf2", version = "0.13.0" }
 pkcs1 = { version = "=0.8.0-rc.4", optional = true }
-pkcs5 = "=0.8.0-rc.13"
-pkcs8 = { version = "=0.11.0-rc.11", features = ["encryption", "std"] }
+pkcs5 = "0.8"
+pkcs8 = { version = "0.11", features = ["encryption", "std"] }
 polyval = "0.7.1" # only pinned due to a cargo-minimal-versions failure in 0.7.0
 rand_core = { version = "0.10.0" }
 rand.workspace = true
 ring = { version = "0.17.14", optional = true }
-rsa = { version = "=0.10.0-rc.16", optional = true }
+rsa = { version = "0.10.0-rc.18", optional = true }
 russh-cryptovec = { version = "0.59.0", path = "../cryptovec", features = [
   "ssh-encoding",
 ] }
@@ -104,7 +104,7 @@ sha2.workspace = true
 sha2_0_11 = { package = "sha2", version = "0.11.0" }
 sha3 = "0.11.0"
 signature.workspace = true
-spki = "=0.8.0-rc.4"
+spki = "0.8"
 ssh-encoding.workspace = true
 ssh-key.workspace = true
 subtle = "2.4"

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -70,7 +70,7 @@ inout = { version = "0.1", features = ["std"] }
 keccak = "0.2.0"
 log.workspace = true
 md5 = "0.7"
-ml-kem = "=0.3.0-rc.1"
+ml-kem = "0.3"
 module-lattice = "0.2"
 # num-bigint 0.4.x only supports rand 0.8. PR #338 adds rand 0.10 support
 # via the `rand_0_10` feature flag. Replace with upstream once a release with

--- a/russh/src/keys/format/pkcs8.rs
+++ b/russh/src/keys/format/pkcs8.rs
@@ -129,7 +129,7 @@ pub fn encode_pkcs8_encrypted(
     rng.fill_bytes(&mut iv);
 
     let doc = pvi.encrypt_with_params(
-        pkcs5::pbes2::Parameters::pbkdf2_sha256_aes256cbc(rounds, &salt, iv)
+        pkcs5::pbes2::Parameters::generate_pbkdf2_sha256_aes256cbc(rounds, &salt, iv)
             .map_err(|_| Error::InvalidParameters)?,
         pass,
     )?;


### PR DESCRIPTION
## Context

After `pkcs8 0.11.0` stable landed (2026-04-28, see [#697](https://github.com/warp-tech/russh/issues/697)), russh's prerelease crypto stack falls over for any downstream consumer that pulls in `rsa = "^0.10.0-rc.18"`. Issue #697 was closed by `2a49916` with a stopgap that pins every prerelease dep with `=`, releasing as 0.60.2. That fixes russh in isolation but blocks downstream consumers: their newer rsa pulls in `pkcs8 0.11.0` stable through the dep graph, which makes 0.60.2's `rsa = "=0.10.0-rc.16"` and `pkcs8 = "=0.11.0-rc.11"` unresolvable in the same workspace.

This PR completes the work of #697 by migrating russh's source to the stable `pkcs5` / `pkcs8` / `ed25519` APIs and loosening the prerelease pins so the resolver can climb to versions that compile against the stable formats family.

## Change

Source change in `russh/src/keys/format/pkcs8.rs`:

```
- pkcs5::pbes2::Parameters::pbkdf2_sha256_aes256cbc(rounds, &salt, iv)
+ pkcs5::pbes2::Parameters::generate_pbkdf2_sha256_aes256cbc(rounds, &salt, iv)
```

The `pbkdf2_sha256_aes256cbc` constructor existed in `pkcs5 0.8.0-rc.13` and was renamed to `generate_pbkdf2_sha256_aes256cbc` in `0.8.0` stable (per the `pkcs5` CHANGELOG and current docs.rs). Same arguments, same crypto semantics.

Floor bumps in `russh/Cargo.toml`:

| Crate | Before | After |
| --- | --- | --- |
| `crypto-bigint` | `=0.7.0-rc.28` | `0.7.3` |
| `ecdsa` | `=0.17.0-rc.16` | `0.17.0-rc.18` |
| `ed25519-dalek` | `=3.0.0-pre.6` | `3.0.0-pre.7` |
| `elliptic-curve` | `=0.14.0-rc.28` | `0.14.0-rc.32` |
| `p256` / `p384` / `p521` | `=0.14.0-rc.7` | `0.14.0-rc.9` |
| `pkcs5` | `=0.8.0-rc.13` | `0.8` (stable) |
| `pkcs8` | `=0.11.0-rc.11` | `0.11` (stable) |
| `rsa` | `=0.10.0-rc.16` | `0.10.0-rc.18` |
| `spki` | `=0.8.0-rc.4` | `0.8` (stable) |

The `=` prefix is dropped on every line above. Each new floor is the first version of the crate that compiles against the stable formats family. The cascade is forced because `rsa 0.10.0-rc.16` source itself fails against `pkcs8 0.11.0` stable with the same `KeyMalformed` enum-variant signature change that broke `ed25519-rc.4` in the #697 report, and `primefield 0.14.0-rc.7` (pulled in via `p256`/`p384`/`p521 0.14.0-rc.7`) fails against `crypto-bigint 0.7.3` with const-generic type-inference errors.

Other prerelease pins (`aead`, `aes-gcm`, `curve25519-dalek`, `ml-kem`, the `internal-russh-num-bigint` fork, `pkcs1`) are left untouched. Each of those crates' latest published version equals the pinned version today, so loosening would be a no-op for resolution.

## Verification

On the fork branch with `rustc 1.88.0` (the `rust-toolchain.toml` floor):

```
cargo build --workspace                                   clean
cargo build --workspace --all-features                    clean
cargo clippy --workspace -- -D warnings                   clean
cargo clippy --workspace --all-features -- -D warnings    clean
cargo fmt --check                                         clean
cargo test --workspace                                    76 lib tests + all
                                                          submodule and doc-tests
                                                          pass
cargo test --workspace --all-features                     77 lib tests + all
                                                          submodule and doc-tests
                                                          pass
```

`cargo minimal-versions check --all-features --no-dev-deps` was not run locally (cargo-minimal-versions and cargo-hack are not installed in the development environment). The new floors are chosen so the lowest version satisfying each loosened spec is the first version that compiles against the stable formats family, which is what `minimal-versions` selects in the absence of an `=` pin. CI is the canonical check.

## Downstream evidence

The fix unblocks at least one downstream consumer: the rustfs SFTP server. The rustfs feature branch carries:

```
[patch.crates-io]
russh = { git = "https://github.com/simon-escapecode/russh", branch = "fix/697-migrate-stable-crypto-stack" }
```

against rustfs's `russh = "0.60.0"` workspace dep. With this patch in place, rustfs resolves cleanly against `rsa 0.10.0-rc.18`, `pkcs5 0.8.0` stable, `pkcs8 0.11.0` stable, `ed25519 3.0.0` stable, and the rest of the stable formats family. Without the patch, the rustfs build fails on the same `KeyMalformed` signature mismatch in `rsa 0.10.0-rc.16` source that blocks anyone else trying to consume rsa rc.18+ alongside russh 0.60.2.

## Risk

The bumps `ed25519-dalek 3.0.0-pre.6 -> 3.0.0-pre.7`, `ecdsa rc.16 -> rc.18`, `elliptic-curve rc.28 -> rc.32`, and `p256` / `p384` / `p521 rc.7 -> rc.9` are minor RustCrypto patch-level moves. The russh test suite covers the affected key handling and ECDSA / EdDSA paths and passes on the fork at every step. The `rsa = "=0.10.0-rc.16" -> "0.10.0-rc.18"` move is the deliberate fix for downstream compatibility; the `=` was the root cause of #697's downstream impact.

If `cargo minimal-versions check --all-features --no-dev-deps` flags any further floor that the in-tree CI catches, the fix shape is the same: bump the floor to the first version that compiles against the stable formats family. Happy to amend.
