### PR TITLE
fix: support SEC1 EC keys with full domain parameters

### DIFF
--- a/russh/src/keys/format/pkcs8.rs
+++ b/russh/src/keys/format/pkcs8.rs
@@ -34,7 +34,12 @@ pub fn decode_pkcs8(
             Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?)
         }
         Err(_) => {
-            // ASN.1 key
+            // SEC1 key with full domain parameters (not a named curve OID)
+            match decode_sec1_with_full_domain_params(ciphertext) {
+                Ok(kp) => return Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?),
+                Err(_) => {},
+            }
+            // ASN.1 key (PKCS#8)
             Ok(
                 pkcs8_pki_into_keypair_data(doc.decode_msg::<PrivateKeyInfoRef<'_>>()?)?
                     .try_into()?,
@@ -110,6 +115,194 @@ where
         }
         oid => return Err(Error::UnknownAlgorithm(oid)),
     })
+}
+
+/// Try to manually parse an SEC1 EC key with full domain parameters.
+///
+/// Some key generators (e.g. OpenSSL with certain options) produce SEC1 keys
+/// where the `[0]` parameters field contains full EC domain parameters instead
+/// of a named curve OID. The `sec1` crate does not support this format.
+/// This function manually parses the DER to extract the curve and private key.
+fn decode_sec1_with_full_domain_params(der: &[u8]) -> Result<EcdsaKeypair, Error> {
+    if der.is_empty() || der[0] != 0x30 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (header_size, _) = read_der_len(&der[1..], der.len() - 1)?;
+    let mut pos = 1 + header_size;
+
+    if pos >= der.len() || der[pos] != 0x02 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (ver, new_pos) = read_der_value(der, pos)?;
+    pos = new_pos;
+    // SEC1 version must be 1 (ecPrivkeyVer1)
+    if ver.len() != 1 || ver[0] < 1 {
+        return Err(Error::CouldNotReadKey);
+    }
+
+    if pos >= der.len() || der[pos] != 0x04 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (priv_key, new_pos) = read_der_value(der, pos)?;
+    pos = new_pos;
+
+    if pos >= der.len() || der[pos] != 0xa0 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (params_content, _) = read_der_value(der, pos)?;
+
+    if params_content.is_empty() || params_content[0] != 0x30 {
+        return Err(Error::CouldNotReadKey);
+    }
+
+    let curve_oid = extract_curve_from_domain_params(params_content)?;
+    build_ec_keypair_from_bytes(curve_oid, priv_key)
+}
+
+/// Read a DER TLV (tag-length-value) from `der` starting at `pos`.
+/// Returns (value_bytes, next_position_after_this_tlv).
+fn read_der_value(der: &[u8], pos: usize) -> Result<(&[u8], usize), Error> {
+    if pos >= der.len() {
+        return Err(Error::CouldNotReadKey);
+    }
+    // read_der_len reads from the LENGTH field (pos + 1, after the tag byte).
+    // It returns (length_field_size, length_field_size + content_length).
+    // So total_size = header_size + content_size (relative to length field start).
+    let (length_field_size, total_from_len_field) = read_der_len(&der[pos + 1..], der.len() - pos - 1)?;
+    let header_size = 1 + length_field_size; // tag byte + length field bytes
+    let value_start = pos + header_size;
+    let value_end = pos + 1 + total_from_len_field; // 1 for tag + total_from_len_field
+    if value_end > der.len() || value_start > value_end {
+        return Err(Error::CouldNotReadKey);
+    }
+    Ok((&der[value_start..value_end], value_end))
+}
+
+/// Read a DER length field from `buf` (which starts at the length byte, after the tag).
+///
+/// Returns `(length_field_size, length_field_size + content_length)`:
+/// - `length_field_size`: number of bytes used to encode the length itself (1 for short form, 1+N for long form)
+/// - `length_field_size + content_length`: total bytes consumed (length field + content)
+///
+/// `max` is the number of available bytes in `buf` (used for bounds checking).
+fn read_der_len(buf: &[u8], max: usize) -> Result<(usize, usize), Error> {
+    if buf.is_empty() {
+        return Err(Error::CouldNotReadKey);
+    }
+    let first = buf[0];
+    if first & 0x80 == 0 {
+        let len = first as usize;
+        if 1 + len > max {
+            return Err(Error::CouldNotReadKey);
+        }
+        Ok((1, 1 + len))
+    } else {
+        let num_bytes = (first & 0x7f) as usize;
+        if num_bytes == 0 || 1 + num_bytes > max {
+            return Err(Error::CouldNotReadKey);
+        }
+        let mut len = 0usize;
+        for &b in &buf[1..1 + num_bytes] {
+            len = (len << 8) | b as usize;
+        }
+        if 1 + num_bytes + len > max {
+            return Err(Error::CouldNotReadKey);
+        }
+        Ok((1 + num_bytes, 1 + num_bytes + len))
+    }
+}
+
+/// Extract the named curve OID from full EC domain parameters.
+/// Handles two formats:
+/// 1. Standard ECParameters: SEQUENCE { FieldID, Curve, base, order, cofactor }
+/// 2. Wrapped ECParameters: SEQUENCE { INTEGER version, SEQUENCE { FieldID, ... } }
+fn extract_curve_from_domain_params(params_der: &[u8]) -> Result<ObjectIdentifier, Error> {
+    if params_der.is_empty() || params_der[0] != 0x30 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (header_size, _) = read_der_len(&params_der[1..], params_der.len() - 1)?;
+    let mut pos = 1 + header_size; // skip SEQUENCE tag + length bytes
+
+    if pos >= params_der.len() {
+        return Err(Error::CouldNotReadKey);
+    }
+
+    // If the first element is an INTEGER (version), skip it to reach FieldID SEQUENCE
+    if params_der[pos] == 0x02 {
+        let (_, skip_pos) = read_der_value(params_der, pos)?;
+        pos = skip_pos;
+    }
+
+    // Now pos should point to the FieldID SEQUENCE
+    if pos >= params_der.len() || params_der[pos] != 0x30 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (field_id_content, _new_pos) = read_der_value(params_der, pos)?;
+
+    // Parse FieldID: first element is OID (prime-field = 1.2.840.10045.1.1)
+    if field_id_content.is_empty() || field_id_content[0] != 0x06 {
+        return Err(Error::CouldNotReadKey);
+    }
+    // OID 1.2.840.10045.1.1 (prime-field from ANSI X9.62):
+    //   DER tag 0x06, length 0x07, then 7 bytes of OID content
+    //   2a = 1.2, 86 48 = 840, ce 3d = 10045, 01 = 1, 01 = 1
+    // This is a stable ASN.1 standard OID that will not change.
+    let prime_field_der: &[u8] = &[0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x01, 0x01];
+    let oid_len = field_id_content[1] as usize;
+    let oid_end = 2 + oid_len;
+    if oid_end > field_id_content.len() || &field_id_content[..oid_end] != prime_field_der {
+        return Err(Error::CouldNotReadKey);
+    }
+    let prime_pos = oid_end;
+
+    if prime_pos >= field_id_content.len() || field_id_content[prime_pos] != 0x02 {
+        return Err(Error::CouldNotReadKey);
+    }
+    let (prime_bytes, _) = read_der_value(field_id_content, prime_pos)?;
+
+    // Determine curve from prime byte length.
+    // DER INTEGERs are signed, so when the high bit of the first content byte is set,
+    // a leading 0x00 pad byte is added to keep the value positive. For example, the
+    // P-256 prime (a 256-bit value with high bit set) encodes as 33 bytes: 0x00 || 32-byte-prime.
+    // We match both padded (33/49/67) and unpadded (32/48/66) lengths.
+    let prime_len = prime_bytes.len();
+    Ok(match prime_len {
+        32 | 33 => NistP256::OID,  // P-256: secp256r1 prime is 32 bytes
+        48 | 49 => NistP384::OID,  // P-384: secp384r1 prime is 48 bytes
+        66 | 67 => NistP521::OID,  // P-521: secp521r1 prime is 66 bytes
+        _ => return Err(Error::CouldNotReadKey),
+    })
+}
+
+/// Build an EcdsaKeypair from raw private key bytes and a curve OID.
+fn build_ec_keypair_from_bytes(
+    curve_oid: ObjectIdentifier,
+    private_key_bytes: &[u8],
+) -> Result<EcdsaKeypair, Error> {
+    if curve_oid == NistP256::OID {
+        let sk = p256::SecretKey::from_slice(private_key_bytes)
+            .map_err(|_| Error::CouldNotReadKey)?;
+        Ok(EcdsaKeypair::NistP256 {
+            public: sk.public_key().into(),
+            private: sk.into(),
+        })
+    } else if curve_oid == NistP384::OID {
+        let sk = p384::SecretKey::from_slice(private_key_bytes)
+            .map_err(|_| Error::CouldNotReadKey)?;
+        Ok(EcdsaKeypair::NistP384 {
+            public: sk.public_key().into(),
+            private: sk.into(),
+        })
+    } else if curve_oid == NistP521::OID {
+        let sk = p521::SecretKey::from_slice(private_key_bytes)
+            .map_err(|_| Error::CouldNotReadKey)?;
+        Ok(EcdsaKeypair::NistP521 {
+            public: sk.public_key().into(),
+            private: sk.into(),
+        })
+    } else {
+        Err(Error::UnknownAlgorithm(curve_oid))
+    }
 }
 
 /// Encode into a password-protected PKCS#8-encoded private key.

--- a/russh/src/keys/format/pkcs8.rs
+++ b/russh/src/keys/format/pkcs8.rs
@@ -24,28 +24,22 @@ pub fn decode_pkcs8(
         doc
     };
 
-    match doc.decode_msg::<sec1::EcPrivateKey>() {
-        Ok(key) => {
-            // X9.62 EC private key
-            let Some(curve) = key.parameters.and_then(|x| x.named_curve()) else {
-                return Err(Error::CouldNotReadKey);
-            };
-            let kp = ec_key_data_into_keypair(curve, key)?;
-            Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?)
-        }
-        Err(_) => {
-            // SEC1 key with full domain parameters (not a named curve OID)
-            match decode_sec1_with_full_domain_params(ciphertext) {
-                Ok(kp) => return Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?),
-                Err(_) => {},
-            }
-            // ASN.1 key (PKCS#8)
-            Ok(
-                pkcs8_pki_into_keypair_data(doc.decode_msg::<PrivateKeyInfoRef<'_>>()?)?
-                    .try_into()?,
-            )
-        }
+    if let Ok(key) = doc.decode_msg::<sec1::EcPrivateKey>() {
+        // X9.62 EC private key
+        let Some(curve) = key.parameters.and_then(|x| x.named_curve()) else {
+            return Err(Error::CouldNotReadKey);
+        };
+        let kp = ec_key_data_into_keypair(curve, key)?;
+        return Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?);
     }
+
+    // SEC1 key with full domain parameters (not a named curve OID)
+    if let Ok(kp) = explicit_curve_params::decode_sec1_with_full_domain_params(ciphertext) {
+        return Ok(PrivateKey::new(KeypairData::Ecdsa(kp), "")?);
+    }
+
+    // ASN.1 key (PKCS#8)
+    Ok(pkcs8_pki_into_keypair_data(doc.decode_msg::<PrivateKeyInfoRef<'_>>()?)?.try_into()?)
 }
 
 fn pkcs8_pki_into_keypair_data(pki: PrivateKeyInfoRef<'_>) -> Result<KeypairData, Error> {
@@ -117,191 +111,102 @@ where
     })
 }
 
-/// Try to manually parse an SEC1 EC key with full domain parameters.
-///
-/// Some key generators (e.g. OpenSSL with certain options) produce SEC1 keys
-/// where the `[0]` parameters field contains full EC domain parameters instead
-/// of a named curve OID. The `sec1` crate does not support this format.
-/// This function manually parses the DER to extract the curve and private key.
-fn decode_sec1_with_full_domain_params(der: &[u8]) -> Result<EcdsaKeypair, Error> {
-    if der.is_empty() || der[0] != 0x30 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (header_size, _) = read_der_len(&der[1..], der.len() - 1)?;
-    let mut pos = 1 + header_size;
+mod explicit_curve_params {
+    use super::*;
 
-    if pos >= der.len() || der[pos] != 0x02 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (ver, new_pos) = read_der_value(der, pos)?;
-    pos = new_pos;
-    // SEC1 version must be 1 (ecPrivkeyVer1)
-    if ver.len() != 1 || ver[0] < 1 {
-        return Err(Error::CouldNotReadKey);
-    }
+    use der::{
+        Reader, SliceReader, Tag, TagNumber, Tagged,
+        asn1::{AnyRef, ContextSpecific, UintRef},
+    };
 
-    if pos >= der.len() || der[pos] != 0x04 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (priv_key, new_pos) = read_der_value(der, pos)?;
-    pos = new_pos;
+    /// Try to parse an SEC1 EC key with full domain parameters.
+    ///
+    /// Some key generators (e.g. OpenSSL with certain options) produce SEC1 keys
+    /// where the `[0]` parameters field contains full EC domain parameters instead
+    /// of a named curve OID. The `sec1` crate does not support this format.
+    pub fn decode_sec1_with_full_domain_params(der_bytes: &[u8]) -> Result<EcdsaKeypair, Error> {
+        let mut reader = SliceReader::new(der_bytes)?;
+        reader.sequence(|seq| {
+            let version: u8 = seq.decode()?;
+            if version < 1 {
+                return Err(Error::CouldNotReadKey);
+            }
 
-    if pos >= der.len() || der[pos] != 0xa0 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (params_content, _) = read_der_value(der, pos)?;
+            let priv_key: AnyRef = seq.decode()?;
+            priv_key.tag().assert_eq(Tag::OctetString)?;
 
-    if params_content.is_empty() || params_content[0] != 0x30 {
-        return Err(Error::CouldNotReadKey);
-    }
+            let params = ContextSpecific::<AnyRef>::decode_explicit(seq, TagNumber(0))?
+                .ok_or(Error::CouldNotReadKey)?;
 
-    let curve_oid = extract_curve_from_domain_params(params_content)?;
-    build_ec_keypair_from_bytes(curve_oid, priv_key)
-}
+            let curve_oid = extract_curve_from_domain_params(params.value)?;
 
-/// Read a DER TLV (tag-length-value) from `der` starting at `pos`.
-/// Returns (value_bytes, next_position_after_this_tlv).
-fn read_der_value(der: &[u8], pos: usize) -> Result<(&[u8], usize), Error> {
-    if pos >= der.len() {
-        return Err(Error::CouldNotReadKey);
-    }
-    // read_der_len reads from the LENGTH field (pos + 1, after the tag byte).
-    // It returns (length_field_size, length_field_size + content_length).
-    // So total_size = header_size + content_size (relative to length field start).
-    let (length_field_size, total_from_len_field) = read_der_len(&der[pos + 1..], der.len() - pos - 1)?;
-    let header_size = 1 + length_field_size; // tag byte + length field bytes
-    let value_start = pos + header_size;
-    let value_end = pos + 1 + total_from_len_field; // 1 for tag + total_from_len_field
-    if value_end > der.len() || value_start > value_end {
-        return Err(Error::CouldNotReadKey);
-    }
-    Ok((&der[value_start..value_end], value_end))
-}
+            let keypair = build_ec_keypair_from_bytes(curve_oid, priv_key.value())?;
 
-/// Read a DER length field from `buf` (which starts at the length byte, after the tag).
-///
-/// Returns `(length_field_size, length_field_size + content_length)`:
-/// - `length_field_size`: number of bytes used to encode the length itself (1 for short form, 1+N for long form)
-/// - `length_field_size + content_length`: total bytes consumed (length field + content)
-///
-/// `max` is the number of available bytes in `buf` (used for bounds checking).
-fn read_der_len(buf: &[u8], max: usize) -> Result<(usize, usize), Error> {
-    if buf.is_empty() {
-        return Err(Error::CouldNotReadKey);
-    }
-    let first = buf[0];
-    if first & 0x80 == 0 {
-        let len = first as usize;
-        if 1 + len > max {
-            return Err(Error::CouldNotReadKey);
-        }
-        Ok((1, 1 + len))
-    } else {
-        let num_bytes = (first & 0x7f) as usize;
-        if num_bytes == 0 || 1 + num_bytes > max {
-            return Err(Error::CouldNotReadKey);
-        }
-        let mut len = 0usize;
-        for &b in &buf[1..1 + num_bytes] {
-            len = (len << 8) | b as usize;
-        }
-        if 1 + num_bytes + len > max {
-            return Err(Error::CouldNotReadKey);
-        }
-        Ok((1 + num_bytes, 1 + num_bytes + len))
-    }
-}
-
-/// Extract the named curve OID from full EC domain parameters.
-/// Handles two formats:
-/// 1. Standard ECParameters: SEQUENCE { FieldID, Curve, base, order, cofactor }
-/// 2. Wrapped ECParameters: SEQUENCE { INTEGER version, SEQUENCE { FieldID, ... } }
-fn extract_curve_from_domain_params(params_der: &[u8]) -> Result<ObjectIdentifier, Error> {
-    if params_der.is_empty() || params_der[0] != 0x30 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (header_size, _) = read_der_len(&params_der[1..], params_der.len() - 1)?;
-    let mut pos = 1 + header_size; // skip SEQUENCE tag + length bytes
-
-    if pos >= params_der.len() {
-        return Err(Error::CouldNotReadKey);
-    }
-
-    // If the first element is an INTEGER (version), skip it to reach FieldID SEQUENCE
-    if params_der[pos] == 0x02 {
-        let (_, skip_pos) = read_der_value(params_der, pos)?;
-        pos = skip_pos;
-    }
-
-    // Now pos should point to the FieldID SEQUENCE
-    if pos >= params_der.len() || params_der[pos] != 0x30 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (field_id_content, _new_pos) = read_der_value(params_der, pos)?;
-
-    // Parse FieldID: first element is OID (prime-field = 1.2.840.10045.1.1)
-    if field_id_content.is_empty() || field_id_content[0] != 0x06 {
-        return Err(Error::CouldNotReadKey);
-    }
-    // OID 1.2.840.10045.1.1 (prime-field from ANSI X9.62):
-    //   DER tag 0x06, length 0x07, then 7 bytes of OID content
-    //   2a = 1.2, 86 48 = 840, ce 3d = 10045, 01 = 1, 01 = 1
-    // This is a stable ASN.1 standard OID that will not change.
-    let prime_field_der: &[u8] = &[0x06, 0x07, 0x2a, 0x86, 0x48, 0xce, 0x3d, 0x01, 0x01];
-    let oid_len = field_id_content[1] as usize;
-    let oid_end = 2 + oid_len;
-    if oid_end > field_id_content.len() || &field_id_content[..oid_end] != prime_field_der {
-        return Err(Error::CouldNotReadKey);
-    }
-    let prime_pos = oid_end;
-
-    if prime_pos >= field_id_content.len() || field_id_content[prime_pos] != 0x02 {
-        return Err(Error::CouldNotReadKey);
-    }
-    let (prime_bytes, _) = read_der_value(field_id_content, prime_pos)?;
-
-    // Determine curve from prime byte length.
-    // DER INTEGERs are signed, so when the high bit of the first content byte is set,
-    // a leading 0x00 pad byte is added to keep the value positive. For example, the
-    // P-256 prime (a 256-bit value with high bit set) encodes as 33 bytes: 0x00 || 32-byte-prime.
-    // We match both padded (33/49/67) and unpadded (32/48/66) lengths.
-    let prime_len = prime_bytes.len();
-    Ok(match prime_len {
-        32 | 33 => NistP256::OID,  // P-256: secp256r1 prime is 32 bytes
-        48 | 49 => NistP384::OID,  // P-384: secp384r1 prime is 48 bytes
-        66 | 67 => NistP521::OID,  // P-521: secp521r1 prime is 66 bytes
-        _ => return Err(Error::CouldNotReadKey),
-    })
-}
-
-/// Build an EcdsaKeypair from raw private key bytes and a curve OID.
-fn build_ec_keypair_from_bytes(
-    curve_oid: ObjectIdentifier,
-    private_key_bytes: &[u8],
-) -> Result<EcdsaKeypair, Error> {
-    if curve_oid == NistP256::OID {
-        let sk = p256::SecretKey::from_slice(private_key_bytes)
-            .map_err(|_| Error::CouldNotReadKey)?;
-        Ok(EcdsaKeypair::NistP256 {
-            public: sk.public_key().into(),
-            private: sk.into(),
+            // Drain any remaining optional fields (e.g. [1] publicKey) so finish() succeeds
+            seq.drain(seq.remaining_len())?;
+            Ok(keypair)
         })
-    } else if curve_oid == NistP384::OID {
-        let sk = p384::SecretKey::from_slice(private_key_bytes)
-            .map_err(|_| Error::CouldNotReadKey)?;
-        Ok(EcdsaKeypair::NistP384 {
-            public: sk.public_key().into(),
-            private: sk.into(),
+    }
+
+    /// Extract the named curve OID from full EC domain parameters.
+    /// Handles two formats:
+    /// 1. Standard ECParameters: SEQUENCE { FieldID, Curve, base, order, cofactor }
+    /// 2. Wrapped ECParameters: SEQUENCE { INTEGER version, SEQUENCE { FieldID, ... } }
+    fn extract_curve_from_domain_params(params: AnyRef<'_>) -> Result<ObjectIdentifier, Error> {
+        params.tag().assert_eq(Tag::Sequence)?;
+
+        // Use a standalone SliceReader so we aren't required to consume all of ECParams
+        // (Curve, base, order, cofactor follow FieldID but are irrelevant here).
+        let mut seq = SliceReader::new(params.value())?;
+
+        // Skip optional ECParameters version INTEGER
+        if Tag::peek(&seq)? == Tag::Integer {
+            seq.decode::<u8>()?;
+        }
+
+        // FieldID ::= SEQUENCE { fieldType OID, parameters ANY }
+        seq.sequence(|field_id| {
+            let _field_oid: ObjectIdentifier = field_id.decode()?;
+            // prime INTEGER — as_bytes() strips DER sign-extension leading zero
+            let prime: UintRef = field_id.decode()?;
+            Ok(match prime.as_bytes().len() {
+                32 => NistP256::OID,
+                48 => NistP384::OID,
+                66 => NistP521::OID,
+                _ => return Err(Error::CouldNotReadKey),
+            })
         })
-    } else if curve_oid == NistP521::OID {
-        let sk = p521::SecretKey::from_slice(private_key_bytes)
-            .map_err(|_| Error::CouldNotReadKey)?;
-        Ok(EcdsaKeypair::NistP521 {
-            public: sk.public_key().into(),
-            private: sk.into(),
-        })
-    } else {
-        Err(Error::UnknownAlgorithm(curve_oid))
+    }
+
+    /// Build an EcdsaKeypair from raw private key bytes and a curve OID.
+    fn build_ec_keypair_from_bytes(
+        curve_oid: ObjectIdentifier,
+        private_key_bytes: &[u8],
+    ) -> Result<EcdsaKeypair, Error> {
+        if curve_oid == NistP256::OID {
+            let sk = p256::SecretKey::from_slice(private_key_bytes)
+                .map_err(|_| Error::CouldNotReadKey)?;
+            Ok(EcdsaKeypair::NistP256 {
+                public: sk.public_key().into(),
+                private: sk.into(),
+            })
+        } else if curve_oid == NistP384::OID {
+            let sk = p384::SecretKey::from_slice(private_key_bytes)
+                .map_err(|_| Error::CouldNotReadKey)?;
+            Ok(EcdsaKeypair::NistP384 {
+                public: sk.public_key().into(),
+                private: sk.into(),
+            })
+        } else if curve_oid == NistP521::OID {
+            let sk = p521::SecretKey::from_slice(private_key_bytes)
+                .map_err(|_| Error::CouldNotReadKey)?;
+            Ok(EcdsaKeypair::NistP521 {
+                public: sk.public_key().into(),
+                private: sk.into(),
+            })
+        } else {
+            Err(Error::UnknownAlgorithm(curve_oid))
+        }
     }
 }
 

--- a/russh/src/keys/format/tests.rs
+++ b/russh/src/keys/format/tests.rs
@@ -24,3 +24,66 @@ fn test_pkcs8_roundtrip() {
     let decrypted = decode_pkcs8(&encrypted, Some(password)).unwrap();
     assert_eq!(decrypted, original_key);
 }
+
+#[test]
+fn test_ec_private_key_with_full_domain_params() {
+    // This key uses full EC domain parameters instead of a named curve OID.
+    // Generated with: openssl ecparam -name prime256v1 -genkey -param_enc explicit -noout
+    // The sec1 crate cannot parse this format; our fallback parser handles it.
+    let key = "-----BEGIN EC PRIVATE KEY-----\n\
+MIIBaAIBAQQguoBiuFhw88aF2jBBK9zZAxFL3fTXmSnjUt2usONDS+SggfowgfcC\n\
+AQEwLAYHKoZIzj0BAQIhAP////8AAAABAAAAAAAAAAAAAAAA////////////////\n\
+MFsEIP////8AAAABAAAAAAAAAAAAAAAA///////////////8BCBaxjXYqjqT57Pr\n\
+vVV2mIa8ZR0GsMxTsPY7zjw+J9JgSwMVAMSdNgiG5wSTamZ44ROdJreBn36QBEEE\n\
+axfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54W\n\
+K84zV2sxXs7LtkBoN79R9QIhAP////8AAAAA//////////+85vqtpxeehPO5ysL8\n\
+YyVRAgEBoUQDQgAEqZqnpFc/+9yfQh7B/sx5dms/sccAtE+PoGTqAa4y399K1S0H\n\
+b6KBhA+L9No0qBbsdpwaMewJChyf5AIft0Un3A==\n\
+-----END EC PRIVATE KEY-----";
+    let result = decode_secret_key(key, None);
+    assert!(result.is_ok(), "Failed to parse EC key with full domain params: {:?}", result.err());
+    let pk = result.unwrap();
+    assert_eq!(pk.algorithm(), Algorithm::Ecdsa {
+        curve: ssh_key::EcdsaCurve::NistP256,
+    });
+}
+
+#[test]
+fn test_ec_p521_private_key_with_full_domain_params() {
+    // P-521 key with full EC domain parameters (not named curve OID).
+    // Generated with: openssl ecparam -name secp521r1 -genkey -param_enc explicit -noout
+    let key = "-----BEGIN EC PRIVATE KEY-----\n\
+MIICngIBAQRCAH2esSsV6PlGdsc5TekzHNtyj0vhHfok5t0UCXu08hL3ZYqe7JKP\n\
+EjUiuV0NWoo++Zy3juTEB+nssQhOBd4DOBpmoIIBxzCCAcMCAQEwTQYHKoZIzj0B\n\
+AQJCAf//////////////////////////////////////////////////////////\n\
+////////////////////////////MIGfBEIB////////////////////////////\n\
+//////////////////////////////////////////////////////////wEQgBR\n\
+lT65YY4cmh+SmiGgtoVA7qLacluZsxXzuLSJkY7xCeFWGTlR7H6TexZSwL07sb8H\n\
+NXPfiD0sNPHvRR/Ua1A/AAMVANCeiAApHLhTlsxnFzkyhKqg2mS6BIGFBADGhY4G\n\
+twQE6c2ePstmI5W0QpxkgTkFP7Uh+CivYGtNPbqhS1537+dZKP4dwSei/6jeM0iz\n\
+wYVqQpv5fn4xwuW9ZgEYOSlqeJo7wARcil+0LH0b2Zj1RElXm0RoF6+9Fyc+ZiyX\n\
+7nKZXvQmQMVQuQE/rQdhNTxwhqJywkCIvpR2n9FmUAJCAf//////////////////\n\
+////////////////////////+lGGh4O/L5Zrf8wBSPcJpdA7tcm4iZxHrrtvtx6R\n\
+OGQJAgEBoYGJA4GGAAQAtGyQsquetaPetft29sZ1SxWcegQj59V3cSLSaQYpjesA\n\
+ERfIfoSaPbVtCanBcJ4xIPvxaarrGhWCj1B3mjmSDv4B1DDMQiD6jggxZrzg+kRC\n\
+vVH8f9/FHwjQjBWEtctiQzPShusqnD5I3hTBBbX/qh0XaLcLMz0bA0o/HHQ+0xUw\n\
+Aak=\n\
+-----END EC PRIVATE KEY-----";
+    let result = decode_secret_key(key, None);
+    assert!(result.is_ok(), "Failed to parse P-521 key with full domain params: {:?}", result.err());
+    let pk = result.unwrap();
+    assert_eq!(pk.algorithm(), Algorithm::Ecdsa {
+        curve: ssh_key::EcdsaCurve::NistP521,
+    });
+}
+
+#[test]
+fn test_ec_malformed_der_returns_error() {
+    // Completely invalid data — not valid SEC1 or PKCS#8
+    let result = decode_secret_key("-----BEGIN EC PRIVATE KEY-----\nAAAA\n-----END EC PRIVATE KEY-----", None);
+    assert!(result.is_err(), "Should fail on malformed DER");
+
+    // Truncated SEC1 key
+    let result = decode_secret_key("-----BEGIN EC PRIVATE KEY-----\nMIIBaAIBAQQg\n-----END EC PRIVATE KEY-----", None);
+    assert!(result.is_err(), "Should fail on truncated key");
+}


### PR DESCRIPTION
## Problem

SEC1 EC private keys that use full domain parameters (instead of a named curve OID) fail to parse with:

```
Keys(Der(Error { kind: TagUnexpected { expected: Some(Tag(0x10: SEQUENCE)), actual: Tag(0x04: OCTET STRING) }, position: None }))
```

This affects keys generated with `openssl ecparam -param_enc explicit` and similar tools that embed the full EC domain parameters in the `[0]` parameters field of the SEC1 structure.

Fixes #718

## Root Cause

The `sec1` crate's `EcPrivateKey` decoder expects the `[0]` parameters field to contain either a named curve OID or nothing (optional field). But some key generators produce a full EC domain parameters SEQUENCE instead, which the `sec1` crate rejects with a `TagUnexpected` error.

## Fix

Added a manual DER parser as a fallback in `decode_pkcs8` that:

1. Detects SEC1 keys with full domain parameters (when `sec1::EcPrivateKey` decode fails)
2. Extracts the curve OID from the prime field length in the domain parameters
3. Constructs the EC keypair directly from the private key bytes using `p256`/`p384`/`p521` crates

The fallback only runs when the `sec1` crate's strict parser fails, so there is no performance impact on normal keys.

## Changes

- `russh/src/keys/format/pkcs8.rs`: Added fallback parser functions for SEC1 keys with full domain parameters
- `russh/src/keys/format/tests.rs`: Added tests for P-256 and P-521 keys with explicit domain parameters, and negative tests for malformed DER

## Testing

- 165 tests pass, 0 warnings
- New tests cover P-256 and P-521 with explicit domain parameters
- Negative tests for malformed DER and truncated keys
- All existing tests continue to pass
