### PR TITLE
chore(russh): bump russh-sftp dev-dependency 2.1.0 → 2.3.0

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -137,7 +137,7 @@ ratatui = "0.30"
 tempfile = "3.14.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-russh-sftp = "2.1.0"
+russh-sftp = "2.3.0"
 tokio.workspace = true
 tokio-stream.workspace = true
 


### PR DESCRIPTION
## Summary
Bump the `russh-sftp` dev-dependency used by the `sftp_client` / `sftp_server` examples from 2.1.0 to 2.3.0.

## Why
The 2.1.0 → 2.3.0 window includes the merged perf fix from [AspectUnk/russh-sftp#83](https://github.com/AspectUnk/russh-sftp/pull/83) — routing SFTP `WRITE`/`DATA` payloads through `serde_bytes` instead of the generic `VecVisitor` path, ~+29% throughput on large transfers. Examples in this repo should track the version downstream users actually consume.

## Change
One-line bump in `russh/Cargo.toml`:

```diff
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-russh-sftp = "2.1.0"
+russh-sftp = "2.3.0"
```

## Test plan
- [x] `cargo build -p russh --example sftp_client --example sftp_server` → builds clean, no source changes needed (no breaking changes in russh-sftp 2.1 → 2.3 for the API surface these examples use).