### PR TITLE
Update more RustCrypto dependencies to stabilized versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ async-trait = "0.1.50"
 base16ct = "1"
 byteorder = "1.4"
 bytes = "1.7"
-digest = "0.11.0-rc.5"
+digest = "0.11.0"
 delegate = "0.13"
 env_logger = "0.11"
 futures = "0.3"
@@ -17,7 +17,7 @@ log = "0.4.11"
 rand = { version = "0.10", features = ["thread_rng"] }
 sha1 = { version = "0.11", features = ["oid"] }
 sha2 = { version = "0.11", features = ["oid"] }
-signature = "3.0.0-rc.10"
+signature = "3"
 ssh-encoding = { version = "0.3", features = ["bytes"] }
 ssh-key = { version = "=0.7.0-rc.11", features = [
     "ed25519",

--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -38,7 +38,7 @@ bytes.workspace = true
 cbc = { version = "0.2" }
 cipher = "0.5.1" # only pinned due to a cargo-minimal-versions failure in 0.5.0
 ctr = "0.10"
-curve25519-dalek = "=5.0.0-rc.1"
+curve25519-dalek = "5"
 crypto-bigint = { version = "0.7.3", features = ["alloc"] }
 data-encoding = "2.3"
 delegate.workspace = true
@@ -46,7 +46,7 @@ digest.workspace = true
 der = "0.8"
 des = { version = "0.9", optional = true }
 ecdsa = "0.17"
-ed25519-dalek = { version = "=3.0.0-rc.1", features = ["alloc", "rand_core", "pkcs8"] }
+ed25519-dalek = { version = "3", features = ["alloc", "rand_core", "pkcs8"] }
 elliptic-curve = { version = "0.14", features = ["ecdh"] }
 enum_dispatch = "0.3.13"
 flate2 = { version = "1.0.15", optional = true }
@@ -68,9 +68,9 @@ module-lattice = "0.2"
 num-bigint = { package = "internal-russh-num-bigint", version = "=0.5.0", features = ["rand_0_10"] }
 num_bigint_0_4 = { package = "num-bigint", version = "0.4.6" }
 # num-integer = "0.1"
-p256 = { version = "=0.14.0-rc.15", features = ["ecdh"] }
-p384 = { version = "=0.14.0-rc.15", features = ["ecdh"] }
-p521 = { version = "=0.14.0-rc.15", features = ["ecdh"] }
+p256 = { version = "0.14", features = ["ecdh"] }
+p384 = { version = "0.14", features = ["ecdh"] }
+p521 = { version = "0.14", features = ["ecdh"] }
 pbkdf2 = "0.13"
 pkcs1 = { version = "=0.8.0-rc.4", optional = true }
 pkcs5 = "0.8"
@@ -89,7 +89,7 @@ scrypt = "0.12.0"
 sec1 = { version = "0.8", features = ["der"] }
 sha1.workspace = true
 sha2.workspace = true
-sha3 = "0.11.0"
+sha3 = "0.12.0"
 signature.workspace = true
 spki = "0.8"
 ssh-encoding.workspace = true


### PR DESCRIPTION
digest 0.11 has been around for some time, sha3 is a very minor change in it's api.