### PR TITLE
feat(client): support gssapi-with-mic auth

### DIFF
--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -33,6 +33,7 @@ pub enum MethodKind {
     PublicKey,
     HostBased,
     KeyboardInteractive,
+    GssapiWithMic,
 }
 
 impl From<&MethodKind> for &'static str {
@@ -43,6 +44,7 @@ impl From<&MethodKind> for &'static str {
             MethodKind::PublicKey => "publickey",
             MethodKind::HostBased => "hostbased",
             MethodKind::KeyboardInteractive => "keyboard-interactive",
+            MethodKind::GssapiWithMic => "gssapi-with-mic",
         }
     }
 }
@@ -55,6 +57,7 @@ impl FromStr for MethodKind {
             "publickey" => Ok(MethodKind::PublicKey),
             "hostbased" => Ok(MethodKind::HostBased),
             "keyboard-interactive" => Ok(MethodKind::KeyboardInteractive),
+            "gssapi-with-mic" => Ok(MethodKind::GssapiWithMic),
             _ => Err(()),
         }
     }
@@ -119,6 +122,7 @@ impl MethodSet {
             MethodKind::PublicKey,
             MethodKind::HostBased,
             MethodKind::KeyboardInteractive,
+            MethodKind::GssapiWithMic,
         ])
     }
 
@@ -162,6 +166,29 @@ pub trait Signer: Sized {
         hash_alg: Option<HashAlg>,
         to_sign: Vec<u8>,
     ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + Send;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GssapiStep {
+    Continue {
+        token: Vec<u8>,
+    },
+    Complete {
+        token: Option<Vec<u8>>,
+        mic: Option<Vec<u8>>,
+    },
+}
+
+#[cfg_attr(feature = "async-trait", async_trait::async_trait)]
+pub trait GssapiAuthenticator: Sized {
+    type Error: From<crate::SendError>;
+
+    fn gssapi_step(
+        &mut self,
+        selected_mechanism: Vec<u8>,
+        input_token: Option<Vec<u8>>,
+        mic_data: Vec<u8>,
+    ) -> impl Future<Output = Result<GssapiStep, Self::Error>> + Send;
 }
 
 #[derive(Debug, Error)]
@@ -220,6 +247,9 @@ pub enum Method {
     KeyboardInteractive {
         submethods: String,
     },
+    GssapiWithMic {
+        mechanism_oids: Vec<Vec<u8>>,
+    },
     // Hostbased,
 }
 
@@ -258,6 +288,7 @@ pub enum CurrentRequest {
         #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
         submethods: String,
     },
+    GssapiWithMic,
 }
 
 impl AuthRequest {
@@ -281,6 +312,14 @@ impl AuthRequest {
                 current: Some(CurrentRequest::KeyboardInteractive {
                     submethods: submethods.to_string(),
                 }),
+                principal: None,
+                rejection_count: 0,
+            },
+            Method::GssapiWithMic { .. } => Self {
+                initial_methods: MethodSet::all(),
+                methods: MethodSet::all(),
+                partial_success: false,
+                current: Some(CurrentRequest::GssapiWithMic),
                 principal: None,
                 rejection_count: 0,
             },

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -126,6 +126,16 @@ impl MethodSet {
         ])
     }
 
+    pub(crate) fn server_supported() -> Self {
+        Self(vec![
+            MethodKind::None,
+            MethodKind::Password,
+            MethodKind::PublicKey,
+            MethodKind::HostBased,
+            MethodKind::KeyboardInteractive,
+        ])
+    }
+
     pub fn remove(&mut self, method: MethodKind) {
         self.0.retain(|x| *x != method);
     }
@@ -168,27 +178,71 @@ pub trait Signer: Sized {
     ) -> impl Future<Output = Result<Vec<u8>, Self::Error>> + Send;
 }
 
+/// One step of a GSSAPI security context exchange, as produced by a
+/// [`GssapiAuthenticator`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GssapiStep {
+    /// The context is not established yet; send `token` to the server and
+    /// wait for its next token.
     Continue {
         token: Vec<u8>,
     },
+    /// The context is established. `token` is the final output token, if any.
+    /// `mic` is the MIC computed over the `mic_data` passed to
+    /// [`GssapiAuthenticator::gssapi_step`]. Implementations MUST produce a
+    /// MIC whenever the established context supports integrity protection
+    /// (RFC 4462, Section 3.5); `None` falls back to
+    /// `SSH_MSG_USERAUTH_GSSAPI_EXCHANGE_COMPLETE`.
     Complete {
         token: Option<Vec<u8>>,
         mic: Option<Vec<u8>>,
     },
 }
 
+/// A GSS-API error reported by the server during `gssapi-with-mic`
+/// authentication. Informational: the server follows up with an
+/// authentication failure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum GssapiError {
+    /// `SSH_MSG_USERAUTH_GSSAPI_ERROR` (RFC 4462, Section 3.8).
+    Status {
+        major_status: u32,
+        minor_status: u32,
+        message: String,
+    },
+    /// `SSH_MSG_USERAUTH_GSSAPI_ERRTOK` (RFC 4462, Section 3.10). May be
+    /// passed to `GSS_Init_sec_context()` to obtain mechanism-specific
+    /// error details.
+    ErrorToken(Vec<u8>),
+}
+
 #[cfg_attr(feature = "async-trait", async_trait::async_trait)]
 pub trait GssapiAuthenticator: Sized {
     type Error: From<crate::SendError>;
 
+    /// Advance the GSSAPI security context.
+    ///
+    /// `selected_mechanism` is `Some` on the first step and carries the
+    /// DER-encoded OID of the mechanism the server selected; implementations
+    /// must verify it is one of the mechanisms they offered (RFC 4462,
+    /// Section 3.3). It is `None` on subsequent steps.
+    ///
+    /// `input_token` is the token received from the server, if any.
+    /// `mic_data` is the data to compute the final MIC over once the context
+    /// is established.
     fn gssapi_step(
         &mut self,
-        selected_mechanism: Vec<u8>,
+        selected_mechanism: Option<Vec<u8>>,
         input_token: Option<Vec<u8>>,
         mic_data: Vec<u8>,
     ) -> impl Future<Output = Result<GssapiStep, Self::Error>> + Send;
+
+    /// Called when the server reports a GSS-API error; the server follows up
+    /// with an authentication failure. The default implementation ignores
+    /// the error.
+    fn gssapi_error(&mut self, _error: GssapiError) -> impl Future<Output = ()> + Send {
+        async {}
+    }
 }
 
 #[derive(Debug, Error)]
@@ -304,33 +358,22 @@ impl AuthRequest {
     }
 
     pub(crate) fn new(method: &Method) -> Self {
-        match method {
-            Method::KeyboardInteractive { submethods } => Self {
-                initial_methods: MethodSet::all(),
-                methods: MethodSet::all(),
-                partial_success: false,
-                current: Some(CurrentRequest::KeyboardInteractive {
+        let current = match method {
+            Method::KeyboardInteractive { submethods } => {
+                Some(CurrentRequest::KeyboardInteractive {
                     submethods: submethods.to_string(),
-                }),
-                principal: None,
-                rejection_count: 0,
-            },
-            Method::GssapiWithMic { .. } => Self {
-                initial_methods: MethodSet::all(),
-                methods: MethodSet::all(),
-                partial_success: false,
-                current: Some(CurrentRequest::GssapiWithMic),
-                principal: None,
-                rejection_count: 0,
-            },
-            _ => Self {
-                initial_methods: MethodSet::all(),
-                methods: MethodSet::all(),
-                partial_success: false,
-                current: None,
-                principal: None,
-                rejection_count: 0,
-            },
+                })
+            }
+            Method::GssapiWithMic { .. } => Some(CurrentRequest::GssapiWithMic),
+            _ => None,
+        };
+        Self {
+            initial_methods: MethodSet::all(),
+            methods: MethodSet::all(),
+            partial_success: false,
+            current,
+            principal: None,
+            rejection_count: 0,
         }
     }
 

--- a/russh/src/auth.rs
+++ b/russh/src/auth.rs
@@ -115,7 +115,7 @@ impl MethodSet {
         Self(Vec::new())
     }
 
-    pub fn all() -> Self {
+    pub fn client_supported() -> Self {
         Self(vec![
             MethodKind::None,
             MethodKind::Password,
@@ -126,7 +126,7 @@ impl MethodSet {
         ])
     }
 
-    pub(crate) fn server_supported() -> Self {
+    pub fn server_supported() -> Self {
         Self(vec![
             MethodKind::None,
             MethodKind::Password,
@@ -368,8 +368,8 @@ impl AuthRequest {
             _ => None,
         };
         Self {
-            initial_methods: MethodSet::all(),
-            methods: MethodSet::all(),
+            initial_methods: MethodSet::client_supported(),
+            methods: MethodSet::client_supported(),
             partial_success: false,
             current,
             principal: None,

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -145,7 +145,24 @@ impl Session {
                             }
                         }
                         Some((&msg::USERAUTH_INFO_REQUEST_OR_USERAUTH_PK_OK, mut r)) => {
-                            if let Some(auth::CurrentRequest::PublicKey {
+                            if let Some(auth::CurrentRequest::GssapiWithMic) =
+                                auth_request.current
+                            {
+                                debug!("userauth_gssapi_response");
+                                let selected_mechanism = map_err!(Bytes::decode(&mut r))?.to_vec();
+                                map_err!(ensure_end(&r))?;
+                                let mic_data = enc.client_make_gssapi_mic_data(
+                                    &self.common.auth_user,
+                                    &mut self.common.buffer,
+                                )?;
+                                self.sender
+                                    .send(Reply::AuthGssapiResponse {
+                                        selected_mechanism,
+                                        mic_data,
+                                    })
+                                    .map_err(|_| crate::Error::SendError)?;
+                                return Ok(());
+                            } else if let Some(auth::CurrentRequest::PublicKey {
                                 ref mut sent_pk_ok,
                                 ..
                             }) = auth_request.current
@@ -297,6 +314,51 @@ impl Session {
                                 }
                                 _ => {}
                             }
+                        }
+                        Some((&msg::USERAUTH_GSSAPI_TOKEN, mut r)) => {
+                            if let Some(auth::CurrentRequest::GssapiWithMic) =
+                                auth_request.current
+                            {
+                                debug!("userauth_gssapi_token");
+                                let token = map_err!(Bytes::decode(&mut r))?.to_vec();
+                                map_err!(ensure_end(&r))?;
+                                let mic_data = enc.client_make_gssapi_mic_data(
+                                    &self.common.auth_user,
+                                    &mut self.common.buffer,
+                                )?;
+                                self.sender
+                                    .send(Reply::AuthGssapiToken { token, mic_data })
+                                    .map_err(|_| crate::Error::SendError)?;
+                                return Ok(());
+                            }
+                            return Err(crate::Error::Inconsistent.into());
+                        }
+                        Some((&msg::USERAUTH_GSSAPI_ERROR, mut r)) => {
+                            if let Some(auth::CurrentRequest::GssapiWithMic) =
+                                auth_request.current
+                            {
+                                let major_status = map_err!(u32::decode(&mut r))?;
+                                let minor_status = map_err!(u32::decode(&mut r))?;
+                                let message = map_err!(String::decode(&mut r))?;
+                                let _language_tag = map_err!(String::decode(&mut r))?;
+                                map_err!(ensure_end(&r))?;
+                                debug!(
+                                    "userauth_gssapi_error major={major_status} minor={minor_status}: {message}"
+                                );
+                                return Ok(());
+                            }
+                            return Err(crate::Error::Inconsistent.into());
+                        }
+                        Some((&msg::USERAUTH_GSSAPI_ERRTOK, mut r)) => {
+                            if let Some(auth::CurrentRequest::GssapiWithMic) =
+                                auth_request.current
+                            {
+                                let _token = map_err!(Bytes::decode(&mut r))?;
+                                map_err!(ensure_end(&r))?;
+                                debug!("userauth_gssapi_errtok");
+                                return Ok(());
+                            }
+                            return Err(crate::Error::Inconsistent.into());
                         }
                         Some((&msg::EXT_INFO, mut r)) => {
                             return self.handle_ext_info(&mut r).map_err(Into::into);
@@ -936,6 +998,160 @@ impl Session {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::num::Wrapping;
+
+    use byteorder::{BigEndian, ByteOrder};
+    use ssh_encoding::{Decode, Encode};
+
+    use super::*;
+    use crate::compression::{Compression, Decompress};
+    use crate::kex::{KEXES, NONE};
+    use crate::session::Exchange;
+    use crate::{CryptoVec, MethodKind};
+
+    fn test_encrypted() -> Encrypted {
+        Encrypted {
+            state: EncryptedState::Authenticated,
+            exchange: Some(Exchange::default()),
+            kex: KEXES.get(&NONE).unwrap().make(),
+            key: 0,
+            client_mac: crate::mac::NONE,
+            server_mac: crate::mac::NONE,
+            session_id: CryptoVec::from(&b"session-id"[..]),
+            channels: HashMap::new(),
+            last_channel_id: Wrapping(0),
+            write: Vec::new(),
+            write_cursor: 0,
+            last_rekey: russh_util::time::Instant::now(),
+            server_compression: Compression::None,
+            client_compression: Compression::None,
+            decompress: Decompress::None,
+            rekey_wanted: false,
+            received_extensions: Vec::new(),
+            extension_info_awaiters: HashMap::new(),
+        }
+    }
+
+    fn payloads(buf: &[u8]) -> Vec<&[u8]> {
+        let mut payloads = Vec::new();
+        let mut cursor = 0;
+        while cursor < buf.len() {
+            let packet_len = BigEndian::read_u32(&buf[cursor..cursor + 4]) as usize;
+            let payload_start = cursor + 4;
+            let payload_end = payload_start + packet_len;
+            payloads.push(&buf[payload_start..payload_end]);
+            cursor = payload_end;
+        }
+        payloads
+    }
+
+    #[test]
+    fn method_kind_parses_gssapi_with_mic() {
+        assert_eq!(
+            "gssapi-with-mic".parse::<MethodKind>(),
+            Ok(MethodKind::GssapiWithMic)
+        );
+        assert_eq!(<&str>::from(&MethodKind::GssapiWithMic), "gssapi-with-mic");
+    }
+
+    #[test]
+    fn write_auth_request_encodes_gssapi_with_mic() {
+        let krb5_oid = b"\x06\x09\x2a\x86\x48\x86\xf7\x12\x01\x02\x02".to_vec();
+        let mut encrypted = test_encrypted();
+        let wrote = encrypted
+            .write_auth_request(
+                "alice",
+                &auth::Method::GssapiWithMic {
+                    mechanism_oids: vec![krb5_oid.clone()],
+                },
+            )
+            .unwrap();
+        assert!(wrote);
+
+        let payloads = payloads(&encrypted.write);
+        assert_eq!(payloads.len(), 1);
+        let mut r = payloads[0];
+        assert_eq!(u8::decode(&mut r).unwrap(), msg::USERAUTH_REQUEST);
+        assert_eq!(String::decode(&mut r).unwrap(), "alice");
+        assert_eq!(String::decode(&mut r).unwrap(), "ssh-connection");
+        assert_eq!(String::decode(&mut r).unwrap(), "gssapi-with-mic");
+        assert_eq!(u32::decode(&mut r).unwrap(), 1);
+        assert_eq!(Vec::<u8>::decode(&mut r).unwrap(), krb5_oid);
+        ensure_end(&r).unwrap();
+    }
+
+    #[test]
+    fn client_make_gssapi_mic_data_matches_rfc_4462() {
+        let mut encrypted = test_encrypted();
+        let mut got = Vec::new();
+        let mic_data = encrypted
+            .client_make_gssapi_mic_data("alice", &mut got)
+            .unwrap();
+
+        let mut expected = Vec::new();
+        b"session-id".as_slice().encode(&mut expected).unwrap();
+        expected.push(msg::USERAUTH_REQUEST);
+        "alice".encode(&mut expected).unwrap();
+        "ssh-connection".encode(&mut expected).unwrap();
+        "gssapi-with-mic".encode(&mut expected).unwrap();
+        assert_eq!(mic_data, expected);
+        assert_eq!(got, expected);
+    }
+
+    #[test]
+    fn client_send_gssapi_mic_sends_optional_token_before_mic() {
+        let mut encrypted = test_encrypted();
+        encrypted
+            .client_send_gssapi_mic(Some(b"context-token"), b"mic")
+            .unwrap();
+
+        let payloads = payloads(&encrypted.write);
+        assert_eq!(payloads.len(), 2);
+
+        let mut token = payloads[0];
+        assert_eq!(u8::decode(&mut token).unwrap(), msg::USERAUTH_GSSAPI_TOKEN);
+        assert_eq!(
+            Vec::<u8>::decode(&mut token).unwrap(),
+            b"context-token".to_vec()
+        );
+        ensure_end(&token).unwrap();
+
+        let mut mic = payloads[1];
+        assert_eq!(u8::decode(&mut mic).unwrap(), msg::USERAUTH_GSSAPI_MIC);
+        assert_eq!(Vec::<u8>::decode(&mut mic).unwrap(), b"mic".to_vec());
+        ensure_end(&mic).unwrap();
+    }
+
+    #[test]
+    fn client_send_gssapi_exchange_complete_sends_optional_token_first() {
+        let mut encrypted = test_encrypted();
+        encrypted
+            .client_send_gssapi_exchange_complete(Some(b"context-token"))
+            .unwrap();
+
+        let payloads = payloads(&encrypted.write);
+        assert_eq!(payloads.len(), 2);
+
+        let mut token = payloads[0];
+        assert_eq!(u8::decode(&mut token).unwrap(), msg::USERAUTH_GSSAPI_TOKEN);
+        assert_eq!(
+            Vec::<u8>::decode(&mut token).unwrap(),
+            b"context-token".to_vec()
+        );
+        ensure_end(&token).unwrap();
+
+        let mut complete = payloads[1];
+        assert_eq!(
+            u8::decode(&mut complete).unwrap(),
+            msg::USERAUTH_GSSAPI_EXCHANGE_COMPLETE
+        );
+        ensure_end(&complete).unwrap();
+    }
+}
+
 impl Encrypted {
     fn write_auth_request(
         &mut self,
@@ -1020,8 +1236,75 @@ impl Encrypted {
                     submethods.as_bytes().encode(&mut self.write)?;
                     true
                 }
+                auth::Method::GssapiWithMic {
+                    ref mechanism_oids,
+                } => {
+                    user.as_bytes().encode(&mut self.write)?;
+                    "ssh-connection".encode(&mut self.write)?;
+                    "gssapi-with-mic".encode(&mut self.write)?;
+                    (mechanism_oids.len().try_into().unwrap_or(0) as u32)
+                        .encode(&mut self.write)?;
+                    for oid in mechanism_oids {
+                        oid.as_slice().encode(&mut self.write)?;
+                    }
+                    true
+                }
             }
         }))
+    }
+
+    fn client_make_gssapi_mic_data(
+        &mut self,
+        user: &str,
+        buffer: &mut Vec<u8>,
+    ) -> Result<Vec<u8>, crate::Error> {
+        buffer.clear();
+        self.session_id.as_ref().encode(buffer)?;
+        buffer.push(msg::USERAUTH_REQUEST);
+        user.encode(buffer)?;
+        "ssh-connection".encode(buffer)?;
+        "gssapi-with-mic".encode(buffer)?;
+        Ok(buffer.clone())
+    }
+
+    pub(crate) fn client_send_gssapi_token(&mut self, token: &[u8]) -> Result<(), crate::Error> {
+        push_packet!(self.write, {
+            msg::USERAUTH_GSSAPI_TOKEN.encode(&mut self.write)?;
+            token.encode(&mut self.write)?;
+        });
+        Ok(())
+    }
+
+    pub(crate) fn client_send_gssapi_mic(
+        &mut self,
+        token: Option<&[u8]>,
+        mic: &[u8],
+    ) -> Result<(), crate::Error> {
+        if let Some(token) = token
+            && !token.is_empty()
+        {
+            self.client_send_gssapi_token(token)?;
+        }
+        push_packet!(self.write, {
+            msg::USERAUTH_GSSAPI_MIC.encode(&mut self.write)?;
+            mic.encode(&mut self.write)?;
+        });
+        Ok(())
+    }
+
+    pub(crate) fn client_send_gssapi_exchange_complete(
+        &mut self,
+        token: Option<&[u8]>,
+    ) -> Result<(), crate::Error> {
+        if let Some(token) = token
+            && !token.is_empty()
+        {
+            self.client_send_gssapi_token(token)?;
+        }
+        push_packet!(self.write, {
+            msg::USERAUTH_GSSAPI_EXCHANGE_COMPLETE.encode(&mut self.write)?;
+        });
+        Ok(())
     }
 
     fn client_make_to_sign(

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -145,8 +145,7 @@ impl Session {
                             }
                         }
                         Some((&msg::USERAUTH_INFO_REQUEST_OR_USERAUTH_PK_OK, mut r)) => {
-                            if let Some(auth::CurrentRequest::GssapiWithMic) =
-                                auth_request.current
+                            if let Some(auth::CurrentRequest::GssapiWithMic) = auth_request.current
                             {
                                 debug!("userauth_gssapi_response");
                                 let selected_mechanism = map_err!(Bytes::decode(&mut r))?.to_vec();
@@ -316,8 +315,7 @@ impl Session {
                             }
                         }
                         Some((&msg::USERAUTH_GSSAPI_TOKEN, mut r)) => {
-                            if let Some(auth::CurrentRequest::GssapiWithMic) =
-                                auth_request.current
+                            if let Some(auth::CurrentRequest::GssapiWithMic) = auth_request.current
                             {
                                 debug!("userauth_gssapi_token");
                                 let token = map_err!(Bytes::decode(&mut r))?.to_vec();
@@ -334,8 +332,7 @@ impl Session {
                             return Err(crate::Error::Inconsistent.into());
                         }
                         Some((&msg::USERAUTH_GSSAPI_ERROR, mut r)) => {
-                            if let Some(auth::CurrentRequest::GssapiWithMic) =
-                                auth_request.current
+                            if let Some(auth::CurrentRequest::GssapiWithMic) = auth_request.current
                             {
                                 let major_status = map_err!(u32::decode(&mut r))?;
                                 let minor_status = map_err!(u32::decode(&mut r))?;
@@ -359,8 +356,7 @@ impl Session {
                             return Err(crate::Error::Inconsistent.into());
                         }
                         Some((&msg::USERAUTH_GSSAPI_ERRTOK, mut r)) => {
-                            if let Some(auth::CurrentRequest::GssapiWithMic) =
-                                auth_request.current
+                            if let Some(auth::CurrentRequest::GssapiWithMic) = auth_request.current
                             {
                                 let token = map_err!(Bytes::decode(&mut r))?.to_vec();
                                 map_err!(ensure_end(&r))?;
@@ -517,7 +513,9 @@ impl Session {
                 }
 
                 if let Some(sender) = self.channels.remove(&channel_num) {
-                    let _ = sender.send(ChannelMsg::OpenFailure(reason_code.clone())).await;
+                    let _ = sender
+                        .send(ChannelMsg::OpenFailure(reason_code.clone()))
+                        .await;
                 }
 
                 let _ = self.sender.send(Reply::ChannelOpenFailure);
@@ -797,7 +795,9 @@ impl Session {
 
                 match &msg.typ {
                     ChannelType::Session => {
-                        client.server_channel_open_session(channel, reply, self).await?
+                        client
+                            .server_channel_open_session(channel, reply, self)
+                            .await?
                     }
                     ChannelType::DirectTcpip(d) => {
                         client
@@ -866,7 +866,9 @@ impl Session {
                     }
                     ChannelType::Unknown { typ } => {
                         if client.should_accept_unknown_server_channel(id, typ).await {
-                            client.server_channel_open_unknown(channel, reply, self).await?;
+                            client
+                                .server_channel_open_unknown(channel, reply, self)
+                                .await?;
                         } else {
                             debug!("unknown channel type: {typ}");
                             if let Some(ref mut enc) = self.common.encrypted {
@@ -1024,7 +1026,7 @@ mod tests {
     use crate::compression::{Compression, Decompress};
     use crate::kex::{KEXES, NONE};
     use crate::session::Exchange;
-    use crate::{CryptoVec, MethodKind, MethodSet};
+    use crate::{CryptoVec, MethodKind};
 
     fn test_encrypted() -> Encrypted {
         Encrypted {
@@ -1263,9 +1265,7 @@ impl Encrypted {
                     submethods.as_bytes().encode(&mut self.write)?;
                     true
                 }
-                auth::Method::GssapiWithMic {
-                    ref mechanism_oids,
-                } => {
+                auth::Method::GssapiWithMic { ref mechanism_oids } => {
                     user.as_bytes().encode(&mut self.write)?;
                     "ssh-connection".encode(&mut self.write)?;
                     "gssapi-with-mic".encode(&mut self.write)?;

--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -342,9 +342,18 @@ impl Session {
                                 let message = map_err!(String::decode(&mut r))?;
                                 let _language_tag = map_err!(String::decode(&mut r))?;
                                 map_err!(ensure_end(&r))?;
-                                debug!(
+                                warn!(
                                     "userauth_gssapi_error major={major_status} minor={minor_status}: {message}"
                                 );
+                                self.sender
+                                    .send(Reply::AuthGssapiError {
+                                        error: auth::GssapiError::Status {
+                                            major_status,
+                                            minor_status,
+                                            message,
+                                        },
+                                    })
+                                    .map_err(|_| crate::Error::SendError)?;
                                 return Ok(());
                             }
                             return Err(crate::Error::Inconsistent.into());
@@ -353,9 +362,14 @@ impl Session {
                             if let Some(auth::CurrentRequest::GssapiWithMic) =
                                 auth_request.current
                             {
-                                let _token = map_err!(Bytes::decode(&mut r))?;
+                                let token = map_err!(Bytes::decode(&mut r))?.to_vec();
                                 map_err!(ensure_end(&r))?;
-                                debug!("userauth_gssapi_errtok");
+                                warn!("userauth_gssapi_errtok ({} bytes)", token.len());
+                                self.sender
+                                    .send(Reply::AuthGssapiError {
+                                        error: auth::GssapiError::ErrorToken(token),
+                                    })
+                                    .map_err(|_| crate::Error::SendError)?;
                                 return Ok(());
                             }
                             return Err(crate::Error::Inconsistent.into());
@@ -1010,7 +1024,7 @@ mod tests {
     use crate::compression::{Compression, Decompress};
     use crate::kex::{KEXES, NONE};
     use crate::session::Exchange;
-    use crate::{CryptoVec, MethodKind};
+    use crate::{CryptoVec, MethodKind, MethodSet};
 
     fn test_encrypted() -> Encrypted {
         Encrypted {
@@ -1150,6 +1164,19 @@ mod tests {
         );
         ensure_end(&complete).unwrap();
     }
+
+    #[test]
+    fn client_send_gssapi_mic_skips_empty_final_token() {
+        let mut encrypted = test_encrypted();
+        encrypted.client_send_gssapi_mic(Some(b""), b"mic").unwrap();
+
+        let payloads = payloads(&encrypted.write);
+        assert_eq!(payloads.len(), 1);
+        let mut mic = payloads[0];
+        assert_eq!(u8::decode(&mut mic).unwrap(), msg::USERAUTH_GSSAPI_MIC);
+        assert_eq!(Vec::<u8>::decode(&mut mic).unwrap(), b"mic".to_vec());
+        ensure_end(&mic).unwrap();
+    }
 }
 
 impl Encrypted {
@@ -1242,8 +1269,7 @@ impl Encrypted {
                     user.as_bytes().encode(&mut self.write)?;
                     "ssh-connection".encode(&mut self.write)?;
                     "gssapi-with-mic".encode(&mut self.write)?;
-                    (mechanism_oids.len().try_into().unwrap_or(0) as u32)
-                        .encode(&mut self.write)?;
+                    (mechanism_oids.len() as u32).encode(&mut self.write)?;
                     for oid in mechanism_oids {
                         oid.as_slice().encode(&mut self.write)?;
                     }
@@ -1280,9 +1306,7 @@ impl Encrypted {
         token: Option<&[u8]>,
         mic: &[u8],
     ) -> Result<(), crate::Error> {
-        if let Some(token) = token
-            && !token.is_empty()
-        {
+        if let Some(token) = token.filter(|t| !t.is_empty()) {
             self.client_send_gssapi_token(token)?;
         }
         push_packet!(self.write, {
@@ -1296,9 +1320,7 @@ impl Encrypted {
         &mut self,
         token: Option<&[u8]>,
     ) -> Result<(), crate::Error> {
-        if let Some(token) = token
-            && !token.is_empty()
-        {
+        if let Some(token) = token.filter(|t| !t.is_empty()) {
             self.client_send_gssapi_token(token)?;
         }
         push_packet!(self.write, {

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -130,6 +130,14 @@ enum Reply {
         instructions: String,
         prompts: Vec<Prompt>,
     },
+    AuthGssapiResponse {
+        selected_mechanism: Vec<u8>,
+        mic_data: Vec<u8>,
+    },
+    AuthGssapiToken {
+        token: Vec<u8>,
+        mic_data: Vec<u8>,
+    },
 }
 
 #[derive(Debug)]
@@ -141,6 +149,16 @@ pub enum Msg {
     },
     AuthInfoResponse {
         responses: Vec<String>,
+    },
+    AuthGssapiToken {
+        token: Vec<u8>,
+    },
+    AuthGssapiMic {
+        token: Option<Vec<u8>>,
+        mic: Vec<u8>,
+    },
+    AuthGssapiExchangeComplete {
+        token: Option<Vec<u8>>,
     },
     Signed {
         data: Vec<u8>,
@@ -517,6 +535,86 @@ impl<H: Handler> Handle<H> {
                 _ => {}
             }
         }
+    }
+
+    /// Authenticate using GSSAPI with MIC (RFC 4462).
+    ///
+    /// `mechanism_oids` contains DER-encoded GSSAPI mechanism OIDs advertised to
+    /// the server. The provided authenticator owns the platform- or
+    /// application-specific GSSAPI implementation and returns continuation
+    /// tokens and, once complete, the MIC over russh's SSH userauth data.
+    pub async fn authenticate_gssapi_with_mic<U: Into<String>, G: auth::GssapiAuthenticator>(
+        &mut self,
+        user: U,
+        mechanism_oids: Vec<Vec<u8>>,
+        authenticator: &mut G,
+    ) -> Result<AuthResult, G::Error> {
+        let user = user.into();
+        if self
+            .sender
+            .send(Msg::Authenticate {
+                user,
+                method: auth::Method::GssapiWithMic { mechanism_oids },
+            })
+            .await
+            .is_err()
+        {
+            return Err((crate::SendError {}).into());
+        }
+        loop {
+            let reply = self.receiver.recv().await;
+            match reply {
+                Some(Reply::AuthSuccess) => return Ok(AuthResult::Success),
+                Some(Reply::AuthFailure {
+                    proceed_with_methods: remaining_methods,
+                    partial_success,
+                }) => {
+                    return Ok(AuthResult::Failure {
+                        remaining_methods,
+                        partial_success,
+                    });
+                }
+                Some(Reply::AuthGssapiResponse {
+                    selected_mechanism,
+                    mic_data,
+                }) => {
+                    let step = authenticator
+                        .gssapi_step(selected_mechanism, None, mic_data)
+                        .await?;
+                    self.send_gssapi_step(step).await?;
+                }
+                Some(Reply::AuthGssapiToken { token, mic_data }) => {
+                    let step = authenticator
+                        .gssapi_step(Vec::new(), Some(token), mic_data)
+                        .await?;
+                    self.send_gssapi_step(step).await?;
+                }
+                None => {
+                    return Ok(AuthResult::Failure {
+                        remaining_methods: MethodSet::empty(),
+                        partial_success: false,
+                    });
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn send_gssapi_step(&mut self, step: auth::GssapiStep) -> Result<(), crate::SendError> {
+        let msg = match step {
+            auth::GssapiStep::Continue { token } => Msg::AuthGssapiToken { token },
+            auth::GssapiStep::Complete {
+                token,
+                mic: Some(mic),
+            } => Msg::AuthGssapiMic { token, mic },
+            auth::GssapiStep::Complete { token, mic: None } => {
+                Msg::AuthGssapiExchangeComplete { token }
+            }
+        };
+        self.sender
+            .send(msg)
+            .await
+            .map_err(|_| crate::SendError {})
     }
 
     /// Authenticate using a certificate with a custom signer that implements the
@@ -1342,6 +1440,21 @@ impl Session {
             }
             Msg::Signed { .. } => {}
             Msg::AuthInfoResponse { .. } => {}
+            Msg::AuthGssapiToken { token } => {
+                if let Some(ref mut enc) = self.common.encrypted {
+                    enc.client_send_gssapi_token(&token)?;
+                }
+            }
+            Msg::AuthGssapiMic { token, mic } => {
+                if let Some(ref mut enc) = self.common.encrypted {
+                    enc.client_send_gssapi_mic(token.as_deref(), &mic)?;
+                }
+            }
+            Msg::AuthGssapiExchangeComplete { token } => {
+                if let Some(ref mut enc) = self.common.encrypted {
+                    enc.client_send_gssapi_exchange_complete(token.as_deref())?;
+                }
+            }
             Msg::ChannelOpenSession { channel_ref } => {
                 let id = self.channel_open_session()?;
                 self.channels.insert(id, channel_ref);

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -138,6 +138,9 @@ enum Reply {
         token: Vec<u8>,
         mic_data: Vec<u8>,
     },
+    AuthGssapiError {
+        error: auth::GssapiError,
+    },
 }
 
 #[derive(Debug)]
@@ -579,15 +582,18 @@ impl<H: Handler> Handle<H> {
                     mic_data,
                 }) => {
                     let step = authenticator
-                        .gssapi_step(selected_mechanism, None, mic_data)
+                        .gssapi_step(Some(selected_mechanism), None, mic_data)
                         .await?;
                     self.send_gssapi_step(step).await?;
                 }
                 Some(Reply::AuthGssapiToken { token, mic_data }) => {
                     let step = authenticator
-                        .gssapi_step(Vec::new(), Some(token), mic_data)
+                        .gssapi_step(None, Some(token), mic_data)
                         .await?;
                     self.send_gssapi_step(step).await?;
+                }
+                Some(Reply::AuthGssapiError { error }) => {
+                    authenticator.gssapi_error(error).await;
                 }
                 None => {
                     return Ok(AuthResult::Failure {

--- a/russh/src/lib_inner.rs
+++ b/russh/src/lib_inner.rs
@@ -32,6 +32,7 @@ mod ssh_read;
 mod sshbuffer;
 
 pub use negotiation::{Names, Preferred};
+pub use auth::{GssapiAuthenticator, GssapiStep};
 
 mod pty;
 

--- a/russh/src/lib_inner.rs
+++ b/russh/src/lib_inner.rs
@@ -32,7 +32,6 @@ mod ssh_read;
 mod sshbuffer;
 
 pub use negotiation::{Names, Preferred};
-pub use auth::{GssapiAuthenticator, GssapiStep};
 
 mod pty;
 
@@ -292,7 +291,9 @@ impl Default for Limits {
     }
 }
 
-pub use auth::{AgentAuthError, MethodKind, MethodSet, Signer};
+pub use auth::{
+    AgentAuthError, GssapiAuthenticator, GssapiError, GssapiStep, MethodKind, MethodSet, Signer,
+};
 
 /// A reason for disconnection.
 #[allow(missing_docs)] // This should be relatively self-explanatory.

--- a/russh/src/msg.rs
+++ b/russh/src/msg.rs
@@ -57,6 +57,13 @@ pub const USERAUTH_INFO_RESPONSE: u8 = 61;
 
 // some numbers have same meaning
 pub const USERAUTH_INFO_REQUEST_OR_USERAUTH_PK_OK: u8 = 60;
+#[allow(dead_code)]
+pub const USERAUTH_GSSAPI_RESPONSE: u8 = 60;
+pub const USERAUTH_GSSAPI_TOKEN: u8 = 61;
+pub const USERAUTH_GSSAPI_EXCHANGE_COMPLETE: u8 = 63;
+pub const USERAUTH_GSSAPI_ERROR: u8 = 64;
+pub const USERAUTH_GSSAPI_ERRTOK: u8 = 65;
+pub const USERAUTH_GSSAPI_MIC: u8 = 66;
 
 // https://tools.ietf.org/html/rfc4254#section-9
 pub const GLOBAL_REQUEST: u8 = 80;

--- a/russh/src/server/encrypted.rs
+++ b/russh/src/server/encrypted.rs
@@ -465,7 +465,7 @@ mod tests {
 
     fn test_auth_encrypted() -> Encrypted {
         Encrypted {
-            state: EncryptedState::WaitingAuthRequest(AuthRequest::server(MethodSet::all())),
+            state: EncryptedState::WaitingAuthRequest(AuthRequest::server(MethodSet::server_supported())),
             exchange: Some(Exchange::default()),
             kex: KEXES.get(&KEX_NONE).expect("none kex").make(),
             key: 0,

--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -108,7 +108,7 @@ impl Default for Config {
                 "_",
                 env!("CARGO_PKG_VERSION")
             ))),
-            methods: auth::MethodSet::all(),
+            methods: auth::MethodSet::server_supported(),
             auth_rejection_time: std::time::Duration::from_secs(1),
             auth_rejection_time_initial: None,
             keys: Vec::new(),


### PR DESCRIPTION
## Summary

Add client-side support for the RFC 4462 `gssapi-with-mic` userauth method. This keeps russh responsible for the SSH protocol flow while leaving platform GSSAPI/Kerberos integration to callers through a new `GssapiAuthenticator` trait. Callers provide DER-encoded mechanism OIDs, consume server GSS tokens, and return continuation tokens or the final MIC.

## Changes

- Add `MethodKind::GssapiWithMic` / `Method::GssapiWithMic`
- Add RFC 4462 GSSAPI userauth message constants:
  - `USERAUTH_GSSAPI_RESPONSE = 60`
  - `USERAUTH_GSSAPI_TOKEN = 61`
  - `USERAUTH_GSSAPI_EXCHANGE_COMPLETE = 63`
  - `USERAUTH_GSSAPI_ERROR = 64`
  - `USERAUTH_GSSAPI_ERRTOK = 65`
  - `USERAUTH_GSSAPI_MIC = 66`
- Add `GssapiAuthenticator` and `GssapiStep`
- Add `Handle::authenticate_gssapi_with_mic`
- Handle server GSSAPI response/token/error/errtok packets in the client auth state machine
- Encode client GSSAPI token, MIC, and exchange-complete packets
- Add protocol-level tests for:
  - method parsing
  - userauth request encoding
  - MIC data construction
  - token/MIC packet ordering
  - exchange-complete packet ordering

## Design Notes

This PR intentionally does not add a dependency on a system GSSAPI library.

Different callers may want to use platform GSS.framework, MIT Kerberos, Heimdal, SSPI, or a fake/test implementation. The trait boundary keeps that platform policy outside russh.

The intended layering is:

```text
russh:
  SSH RFC 4462 protocol flow
  packet constants
  auth state machine
  token/MIC packet encoding
  `GssapiAuthenticator` trait boundary

caller:
  platform GSSAPI/Kerberos/SSPI implementation
  mechanism OID selection
  service principal policy
  credential/cache behavior
```

## Verification

`cargo fmt --check`
`cargo test -p russh gssapi`
`cargo check -p russh`
`cargo test -p russh`