### PR TITLE
Make RunningServer be pub constructable

### DIFF
--- a/russh/src/server/mod.rs
+++ b/russh/src/server/mod.rs
@@ -861,8 +861,8 @@ impl RunningServerHandle {
 }
 
 pub struct RunningServer<F: Future<Output = std::io::Result<()>> + Unpin + Send> {
-    inner: F,
-    shutdown_tx: broadcast::Sender<String>,
+    pub inner: F,
+    pub shutdown_tx: broadcast::Sender<String>,
 }
 
 impl<F: Future<Output = std::io::Result<()>> + Unpin + Send> RunningServer<F> {


### PR DESCRIPTION
- since it's possible to overwrite `Server::run_on_socket`, which returns `RunningServer<>`, the latter must be publicly constructable