### PR TITLE
cryptovec: add Motor OS support

### DIFF
--- a/cryptovec/Cargo.toml
+++ b/cryptovec/Cargo.toml
@@ -29,3 +29,6 @@ wasm-bindgen-test = "0.3.46"
 
 [features]
 ssh-encoding = ["dep:ssh-encoding"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(target_os, values("motor"))'] }

--- a/cryptovec/src/platform/mod.rs
+++ b/cryptovec/src/platform/mod.rs
@@ -3,21 +3,24 @@ mod windows;
 
 #[cfg(not(windows))]
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_os = "motor"))]
 mod unix;
 
-#[cfg(target_arch = "wasm32")]
+// Motor OS has no memory-locking API; it uses the wasm no-op implementation.
+#[cfg(any(target_arch = "wasm32", target_os = "motor"))]
 mod wasm;
 
 // Re-export functions based on the platform
 #[cfg(not(windows))]
 #[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(target_os = "motor"))]
 pub use unix::{mlock, munlock};
-#[cfg(target_arch = "wasm32")]
+#[cfg(any(target_arch = "wasm32", target_os = "motor"))]
 pub use wasm::{mlock, munlock};
 #[cfg(windows)]
 pub use windows::{mlock, munlock};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "motor")))]
 mod error {
     use std::error::Error;
     use std::fmt::Display;
@@ -56,5 +59,5 @@ mod error {
     impl Error for MemoryLockError {}
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(any(target_arch = "wasm32", target_os = "motor")))]
 pub use error::MemoryLockError;


### PR DESCRIPTION
russhd in Motor OS uses russh: https://github.com/moturus/motor-os/tree/main/src/bin/russhd