### PR TITLE
accept a single trailing comma in SSH name-lists

### DIFF
--- a/russh/src/helpers.rs
+++ b/russh/src/helpers.rs
@@ -87,6 +87,16 @@ mod name_list {
             if value.is_empty() {
                 return Ok(Self(Vec::new()));
             }
+
+            // Some legacy SSH implementations append a comma to name-lists.
+            // OpenSSH accepts this, so tolerate exactly one trailing comma for
+            // interoperability while continuing to reject all other empty
+            // entries.
+            let value = value
+                .strip_suffix(',')
+                .filter(|value| !value.is_empty())
+                .unwrap_or(value);
+
             Ok(Self(value.split(',').try_fold(
                 Vec::new(),
                 |mut list, name| {
@@ -150,6 +160,19 @@ mod name_list {
             // An empty entry mid-list (",,") is still invalid — only
             // the zero-length whole-list case is allowed.
             assert!(NameList::from_encoded_string("a,,b").is_err());
+        }
+
+        #[test]
+        fn name_list_accepts_single_trailing_comma() {
+            let nl = NameList::from_encoded_string("a,b,").unwrap();
+            assert_eq!(nl.0, vec!["a", "b"]);
+            assert_eq!(nl.as_encoded_string(), "a,b");
+        }
+
+        #[test]
+        fn name_list_rejects_other_empty_trailing_entries() {
+            assert!(NameList::from_encoded_string(",").is_err());
+            assert!(NameList::from_encoded_string("a,,").is_err());
         }
     }
 }


### PR DESCRIPTION
## Summary

- tolerate exactly one trailing comma when decoding SSH name-lists
- keep rejecting leading, interior, and multiple empty entries
- normalize an accepted list when it is encoded again

## Motivation

Some legacy embedded SSH2 servers append a comma to the cipher and MAC name-lists in their `SSH_MSG_KEXINIT` packet. This was reproduced with an Extreme Networks X670 running ExtremeXOS 16.2.5: OpenSSH accepts the packet, while russh returns `ssh_encoding::Error::CharacterEncoding` before algorithm negotiation can complete.

RFC 4251 requires non-empty name-list elements, so the compatibility relaxation is intentionally narrow: only one delimiter at the very end is ignored. Values such as `,`, `a,,`, and `a,,b` remain invalid.

## Tests

- `cargo test -p russh helpers::name_list::tests`
- `cargo clippy -p russh --tests -- -D warnings`

## AI usage

AI-assisted implementation and PR drafting; the reproduction, behavior, diff, and test results were manually reviewed.
