### PR TITLE
fix(pageant): include NUL terminator in WM_COPYDATA payload

### DIFF
--- a/pageant/src/wmmessage.rs
+++ b/pageant/src/wmmessage.rs
@@ -255,8 +255,8 @@ pub fn query_pageant_direct(cookie: String, msg: &[u8]) -> Result<Vec<u8>, Error
     let char_buffer = CString::new(map_name.as_bytes()).map_err(|_| Error::InvalidCookie)?;
     let cds = COPYDATASTRUCT {
         dwData: _AGENT_COPYDATA_ID as usize,
-        cbData: char_buffer.as_bytes().len() as u32,
-        lpData: char_buffer.as_bytes().as_ptr() as *mut _,
+        cbData: char_buffer.as_bytes_with_nul().len() as u32,
+        lpData: char_buffer.as_bytes_with_nul().as_ptr() as *mut _,
     };
 
     let response = unsafe {


### PR DESCRIPTION
## What does this PR do?

Fixes the legacy WM_COPYDATA Pageant transport by including the
terminating NUL byte in `COPYDATASTRUCT.cbData`.

## Background

This issue was discovered while developing and testing the SSH-agent
forwarding feature in the NyaTerm project.

On Windows, NyaTerm exhibited the following symptoms when authenticating
through Pageant:

```text
SSH Agent identity request failed: early eof
```

Pageant was running with a valid software key loaded. The failure
occurred on a local, non-domain Windows account where
`GetUserNameExA(NameUserPrincipal)` could not resolve the user principal
name. The russh Pageant client then fell back from the named-pipe
transport to the legacy WM_COPYDATA transport.

The same failure was reproduced by NyaTerm's Windows Pageant integration
test.

## Root cause

The Pageant mapping name is created as a `CString`, so the allocated
buffer is NUL-terminated. However, the previous implementation used
`CString::as_bytes()` when populating `COPYDATASTRUCT`:

```rust
cbData: char_buffer.as_bytes().len() as u32,
lpData: char_buffer.as_bytes().as_ptr() as *mut _,
```

`as_bytes()` excludes the terminating NUL from the reported length.
Therefore, although `lpData` points to a NUL-terminated buffer,
`cbData` does not include that byte.

The PuTTY Pageant implementation explicitly validates that the data
described by `COPYDATASTRUCT` is an ASCIZ string and rejects the request
when the final byte is not NUL-terminated:

[PuTTY Pageant implementation](https://browse.dgit.debian.org/putty.git/tree/pageant.c?h=debian%2F0.79-1&id=abe4091f52a2bcf1709c94a45b012b7b46a7b4df)

The rejected request causes the client-side stream to observe an early
EOF.

## Fix

Use `CString::as_bytes_with_nul()` for both the payload length and
pointer:

```rust
cbData: char_buffer.as_bytes_with_nul().len() as u32,
lpData: char_buffer.as_bytes_with_nul().as_ptr() as *mut _,
```

This ensures that `cbData` includes the terminating NUL required by the
Pageant WM_COPYDATA protocol.

The transport selection, memory mapping, and request flow remain
unchanged.

## Validation

The fix was validated on Windows with Pageant running and a software
Ed25519 key loaded.

The NyaTerm Pageant integration test was run with:

```powershell
$env:NYATERM_TEST_WINDOWS_PAGEANT = "1"

cargo test --locked `
    --manifest-path .\src-tauri\Cargo.toml `
    --lib `
    windows_pageant_lists_and_signs_identity `
    -- --ignored --nocapture
```

The test passed after changing only the WM_COPYDATA payload handling:

```text
test core::ssh::agent::windows_integration_tests::windows_pageant_lists_and_signs_identity ... ok
```

The named-pipe implementation was left unchanged. This confirms that
the failure was isolated to the WM_COPYDATA path.

Additional checks:

```text
cargo fmt --all -- --check
git diff --check
```

## Scope

This is a minimal WM_COPYDATA protocol-correctness fix.

It is independent of
[#726](https://github.com/Eugeny/russh/pull/726), which addresses
username fallback for the Windows named-pipe transport.

No named-pipe behavior is changed by this PR.
