### PR TITLE
Support sending custom global requests from the client

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -30,8 +30,8 @@ use crate::keys::key::parse_public_key;
 use crate::parsing::{ChannelOpenConfirmation, ChannelType, OpenChannelMessage, ensure_end};
 use crate::session::{Encrypted, EncryptedState, GlobalRequestResponse};
 use crate::{
-    Channel, ChannelId, ChannelMsg, ChannelOpenFailure, ChannelParams, Error, MethodSet, Sig, auth,
-    map_err, msg,
+    Channel, ChannelId, ChannelMsg, ChannelOpenFailure, ChannelParams, CryptoVec, Error, MethodSet,
+    Sig, auth, map_err, msg,
 };
 
 impl Session {
@@ -962,6 +962,9 @@ impl Session {
                         map_err!(ensure_end(&r))?;
                         let _ = return_channel.send(true);
                     }
+                    Some(GlobalRequestResponse::Other(return_channel)) => {
+                        let _ = return_channel.send(Some(CryptoVec::from_slice(r)));
+                    }
                     None => {
                         error!("Received global request failure for unknown request!")
                     }
@@ -992,6 +995,9 @@ impl Session {
                     }
                     Some(GlobalRequestResponse::CancelStreamLocalForward(return_channel)) => {
                         let _ = return_channel.send(false);
+                    }
+                    Some(GlobalRequestResponse::Other(return_channel)) => {
+                        let _ = return_channel.send(None);
                     }
                     None => {
                         error!("Received global request failure for unknown request!")

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -70,8 +70,8 @@ use crate::session::{CommonSession, EncryptedState, GlobalRequestResponse, NewKe
 use crate::ssh_read::SshRead;
 use crate::sshbuffer::{IncomingSshPacket, PacketWriter, SSHBuffer, SshId};
 use crate::{
-    ChannelId, ChannelOpenFailure, Disconnect, Error, Limits, MethodSet, Sig, auth, map_err, msg,
-    negotiation,
+    ChannelId, ChannelOpenFailure, CryptoVec, Disconnect, Error, Limits, MethodSet, Sig, auth,
+    map_err, msg, negotiation,
 };
 
 mod encrypted;
@@ -240,6 +240,13 @@ pub enum Msg {
     },
     NoMoreSessions {
         want_reply: bool,
+    },
+    /// Send a global request with a custom name to the remote
+    SendGlobalRequest {
+        name: String,
+        data: CryptoVec,
+        /// Provide a channel for the reply result to request a reply from the server
+        reply_channel: Option<oneshot::Sender<Option<CryptoVec>>>,
     },
 }
 
@@ -1056,6 +1063,47 @@ impl<H: Handler> Handle<H> {
             .await
             .map_err(|_| Error::SendError)
     }
+
+    /// Send a global request with a custom, non-standard name to the remote peer.
+    ///
+    /// `data` is the request-specific payload and is appended verbatim after the
+    /// request name and the want-reply flag (see RFC 4254 section 4). When
+    /// `want_reply` is true this waits for the peer's reply and returns its
+    /// response-specific data, which may be empty. When it is false it returns
+    /// `Ok(None)` without waiting for a reply.
+    pub async fn send_global_request<A: Into<String>>(
+        &self,
+        name: A,
+        data: &[u8],
+        want_reply: bool,
+    ) -> Result<Option<CryptoVec>, Error> {
+        let (reply_channel, reply_recv) = if want_reply {
+            let (send, recv) = oneshot::channel();
+            (Some(send), Some(recv))
+        } else {
+            (None, None)
+        };
+        self.sender
+            .send(Msg::SendGlobalRequest {
+                name: name.into(),
+                data: CryptoVec::from_slice(data),
+                reply_channel,
+            })
+            .await
+            .map_err(|_| Error::SendError)?;
+
+        match reply_recv {
+            Some(reply_recv) => match reply_recv.await {
+                Ok(Some(data)) => Ok(Some(data)),
+                Ok(None) => Err(Error::RequestDenied),
+                Err(e) => {
+                    error!("Unable to receive send_global_request result: {e:?}");
+                    Err(Error::Disconnect)
+                }
+            },
+            None => Ok(None),
+        }
+    }
 }
 
 impl<H: Handler> Future for Handle<H> {
@@ -1667,6 +1715,13 @@ impl Session {
             }
             Msg::NoMoreSessions { want_reply } => {
                 let _ = self.no_more_sessions(want_reply);
+            }
+            Msg::SendGlobalRequest {
+                name,
+                data,
+                reply_channel,
+            } => {
+                let _ = self.send_global_request(reply_channel, &name, &data);
             }
             Msg::ServerChannelOpenReply { pending, result } => {
                 self.finalize_server_channel_open_reply(pending, result)?;

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -4,7 +4,7 @@ use tokio::sync::oneshot;
 
 use crate::client::Session;
 use crate::session::EncryptedState;
-use crate::{map_err, msg, ChannelId, Disconnect, Pty, Sig};
+use crate::{map_err, msg, ChannelId, CryptoVec, Disconnect, Pty, Sig};
 
 impl Session {
     fn channel_open_generic<F>(
@@ -398,6 +398,34 @@ impl Session {
                 "cancel-streamlocal-forward@openssh.com".encode(&mut enc.write)?;
                 (want_reply as u8).encode(&mut enc.write)?;
                 socket_path.encode(&mut enc.write)?;
+            });
+        }
+        Ok(())
+    }
+
+    /// Sends a global request with a custom name to the server.
+    ///
+    /// `data` is appended verbatim after the request name and want-reply flag.
+    /// If `reply_channel` is not None, sets want_reply and returns the server's
+    /// response-specific data via the channel, [`Some`] on success or [`None`]
+    /// on failure.
+    pub fn send_global_request(
+        &mut self,
+        reply_channel: Option<oneshot::Sender<Option<CryptoVec>>>,
+        name: &str,
+        data: &[u8],
+    ) -> Result<(), crate::Error> {
+        if let Some(ref mut enc) = self.common.encrypted {
+            let want_reply = reply_channel.is_some();
+            if let Some(reply_channel) = reply_channel {
+                self.open_global_requests
+                    .push_back(crate::session::GlobalRequestResponse::Other(reply_channel));
+            }
+            push_packet!(enc.write, {
+                msg::GLOBAL_REQUEST.encode(&mut enc.write)?;
+                name.encode(&mut enc.write)?;
+                (want_reply as u8).encode(&mut enc.write)?;
+                enc.write.extend_from_slice(data);
             });
         }
         Ok(())

--- a/russh/src/client/test.rs
+++ b/russh/src/client/test.rs
@@ -164,4 +164,64 @@ mod tests {
             msg => panic!("Unexpected message {msg:?}"),
         }
     }
+
+    #[tokio::test]
+    async fn test_send_custom_global_request() {
+        let _ = env_logger::try_init();
+
+        let client_key = PrivateKey::random(&mut rng(), ssh_key::Algorithm::Ed25519).unwrap();
+
+        let mut config = server::Config::default();
+        config.auth_rejection_time = std::time::Duration::from_secs(1);
+        config.inactivity_timeout = None;
+        config
+            .keys
+            .push(PrivateKey::random(&mut rng(), ssh_key::Algorithm::Ed25519).unwrap());
+        let config = Arc::new(config);
+
+        let mut server = TestServer {
+            clients: Arc::new(Mutex::new(HashMap::new())),
+            id: 0,
+        };
+
+        let socket = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = socket.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (socket, _) = socket.accept().await.unwrap();
+            let server_handler = server.new_client(None);
+            server::run_stream(config, socket, server_handler)
+                .await
+                .unwrap();
+        });
+
+        let client_config = Arc::new(Config::default());
+        let mut session = connect(client_config, addr, Client {}).await.unwrap();
+
+        let auth_result = session
+            .authenticate_publickey(
+                std::env::var("USER").unwrap_or("user".to_string()),
+                PrivateKeyWithHashAlg::new(
+                    Arc::new(client_key),
+                    session.best_supported_rsa_hash().await.unwrap().flatten(),
+                ),
+            )
+            .await
+            .unwrap();
+        assert!(auth_result.success());
+
+        // The default server has no handler for this request name, so it replies
+        // with a failure, which surfaces as RequestDenied.
+        let denied = session
+            .send_global_request("custom-request@example.com", b"payload", true)
+            .await;
+        assert!(matches!(denied, Err(Error::RequestDenied)));
+
+        // Without a reply requested the call returns immediately.
+        let no_reply = session
+            .send_global_request("custom-request@example.com", b"payload", false)
+            .await
+            .unwrap();
+        assert!(no_reply.is_none());
+    }
 }

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -811,6 +811,9 @@ pub(crate) enum GlobalRequestResponse {
     /// request was for StreamLocalForward, sends true for success or false for failure
     StreamLocalForward(oneshot::Sender<bool>),
     CancelStreamLocalForward(oneshot::Sender<bool>),
+    /// request had a custom name; sends `Some` with the response-specific
+    /// payload on success or `None` on failure
+    Other(oneshot::Sender<Option<CryptoVec>>),
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This covers the client side of #417. Right now there's no way to send a global request with a non-standard name, so the `config` request from that issue (and anything else outside the built-in forwarding/keepalive ones) isn't reachable.

I added `Handle::send_global_request(name, data, want_reply)` that follows the same pattern as `tcpip_forward` and friends: it pushes the request onto the wire and, when `want_reply` is set, correlates the SUCCESS/FAILURE reply back through a oneshot. On success you get the response-specific payload back (empty if the peer sent none), and a failure comes back as `RequestDenied`. With `want_reply` false it just sends and returns `Ok(None)`.

```rust
let reply = handle.send_global_request("config", payload, true).await?;
```

There's a round-trip test in client/test.rs against the test server, which replies with a failure for the unknown name.

I kept this to the client send path since that's what the issue asks for. Handling incoming custom requests could be a nice follow-up.
