### PR TITLE
Fix enforce rekey read and time limits

### DIFF
--- a/russh/src/cipher/mod.rs
+++ b/russh/src/cipher/mod.rs
@@ -345,10 +345,12 @@ pub(crate) async fn read<R: AsyncRead + Unpin>(
         .len()
         .checked_sub(padding_length)
         .ok_or(Error::IndexOutOfBounds)?;
+    let payload_len = plaintext_end.saturating_sub(PADDING_LENGTH_LEN);
 
     // Sequence numbers are on 32 bits and wrap.
     // https://tools.ietf.org/html/rfc4253#section-6.4
     buffer.seqn += Wrapping(1);
+    buffer.bytes = buffer.bytes.saturating_add(payload_len);
     buffer.len = 0;
 
     // Remove the padding

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -40,7 +40,6 @@ use std::convert::TryInto;
 use std::num::Wrapping;
 use std::pin::Pin;
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
 use std::time::Duration;
 
 use futures::Future;
@@ -1310,6 +1309,8 @@ impl Session {
             // application output in its bounded receivers while a channel is
             // window-blocked.
             let can_receive_outbound = !self.kex.active() && !self.common.has_any_pending_data();
+            let rekey_timer = crate::future_or_pending(self.rekey_time_remaining(), tokio::time::sleep);
+            pin!(rekey_timer);
             tokio::select! {
                 r = &mut reading => {
                     let (stream_read, mut buffer, mut opening_cipher) = match r {
@@ -1331,13 +1332,25 @@ impl Session {
                             result = self.process_disconnect(&pkt).map_err(H::Error::from);
                         } else {
                             self.common.received_data = true;
+                            let kex_was_active = self.kex.active();
                             reply(self, handler, kex_done_signal, &mut pkt).await?;
                             buffer.seqn = pkt.seqn; // TODO reply changes seqn internall, find cleaner way
+
+                            if kex_was_active && !self.kex.active() {
+                                buffer.bytes = 0;
+                            } else if self.read_rekey_limit_reached(buffer.bytes) {
+                                debug!("rekey limit reached after {} inbound bytes", buffer.bytes);
+                                self.initiate_rekey()?;
+                            }
                         }
                     }
 
                     std::mem::swap(&mut opening_cipher, &mut self.common.remote_to_local);
                     reading.set(start_reading(stream_read, buffer, opening_cipher));
+                }
+                () = &mut rekey_timer => {
+                    debug!("rekey time limit reached");
+                    self.initiate_rekey()?;
                 }
                 () = &mut keepalive_timer => {
                     if let Some(ref mut enc) = self.common.encrypted {
@@ -1734,6 +1747,34 @@ impl Session {
         Ok(())
     }
 
+    fn read_rekey_limit_reached(&self, read_bytes: usize) -> bool {
+        !self.kex.active()
+            && self
+                .common
+                .encrypted
+                .as_ref()
+                .is_some_and(|enc| matches!(enc.state, EncryptedState::Authenticated))
+            && read_bytes >= self.common.config.limits.rekey_read_limit
+    }
+
+    fn rekey_time_remaining(&self) -> Option<Duration> {
+        if self.kex.active() {
+            return None;
+        }
+
+        let enc = self.common.encrypted.as_ref()?;
+        if !matches!(enc.state, EncryptedState::Authenticated) {
+            return None;
+        }
+
+        let limit = self.common.config.limits.rekey_time_limit;
+        if limit == Duration::MAX {
+            return None;
+        }
+
+        Some(limit.saturating_sub(Instant::now().duration_since(enc.last_rekey)))
+    }
+
     /// Flush the temporary cleartext buffer into the encryption
     /// buffer. This does *not* flush to the socket.
     fn flush(&mut self) -> Result<(), crate::Error> {
@@ -1742,6 +1783,7 @@ impl Session {
                 &self.common.config.as_ref().limits,
                 &mut self.common.packet_writer,
             )? && !self.kex.active()
+                && matches!(enc.state, EncryptedState::Authenticated)
             {
                 self.begin_rekey()?;
             }
@@ -1969,6 +2011,92 @@ mod tests {
             reply_sender,
         );
         (session, sender, reply_receiver)
+    }
+
+    fn session_with_tiny_rekey_limit(state: EncryptedState) -> Session {
+        let (mut session, sender, _replies) = keyboard_interactive_session();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(0, 0, std::time::Duration::from_secs(3600));
+        let encrypted = session.common.encrypted.as_mut().unwrap();
+        encrypted.state = state;
+        encrypted.kex = KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        drop(sender);
+        session
+    }
+
+    #[test]
+    fn automatic_rekey_waits_until_authentication_completes() {
+        let mut session = session_with_tiny_rekey_limit(
+            EncryptedState::WaitingAuthServiceRequest {
+                accepted: false,
+                sent: false,
+            },
+        );
+
+        session.flush().unwrap();
+
+        assert!(
+            !session.kex.active(),
+            "a pre-authentication write limit must not start a second key exchange"
+        );
+    }
+
+    #[test]
+    fn automatic_rekey_starts_after_authentication() {
+        let mut session =
+            session_with_tiny_rekey_limit(EncryptedState::Authenticated);
+
+        session.flush().unwrap();
+
+        assert!(
+            session.kex.active(),
+            "the same write limit must start rekeying after authentication"
+        );
+    }
+
+    #[test]
+    fn automatic_rekey_starts_at_inbound_read_limit() {
+        let (mut session, sender, _replies) = keyboard_interactive_session();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(
+            1 << 30,
+            16,
+            std::time::Duration::from_secs(3600),
+        );
+        let encrypted = session.common.encrypted.as_mut().unwrap();
+        encrypted.state = EncryptedState::Authenticated;
+        encrypted.kex = KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        drop(sender);
+
+        assert!(!session.read_rekey_limit_reached(15));
+        assert!(session.read_rekey_limit_reached(16));
+        session.initiate_rekey().unwrap();
+
+        assert!(session.kex.active());
+    }
+
+    #[tokio::test]
+    async fn automatic_rekey_deadline_wakes_an_idle_authenticated_session() {
+        let (mut session, sender, _replies) = keyboard_interactive_session();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(1 << 30, 1 << 30, Duration::ZERO);
+        let encrypted = session.common.encrypted.as_mut().unwrap();
+        encrypted.state = EncryptedState::Authenticated;
+        encrypted.kex = KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        drop(sender);
+
+        let remaining = session
+            .rekey_time_remaining()
+            .expect("authenticated sessions with a finite limit need a deadline");
+        tokio::time::timeout(Duration::from_millis(50), tokio::time::sleep(remaining))
+            .await
+            .expect("an expired rekey deadline must wake without transport activity");
+        session.initiate_rekey().unwrap();
+
+        assert!(session.kex.active());
     }
 
     #[cfg(feature = "flate2")]

--- a/russh/src/server/session.rs
+++ b/russh/src/server/session.rs
@@ -710,6 +710,9 @@ impl Session {
                 }
             }
 
+            let rekey_timer = future_or_pending(self.rekey_time_remaining(), tokio::time::sleep);
+            pin!(rekey_timer);
+
             tokio::select! {
                 r = &mut reading => {
                     let (stream_read, mut buffer, mut opening_cipher) = match r {
@@ -735,16 +738,28 @@ impl Session {
                             // TODO it'd be cleaner to just pass cipher to reply()
                             std::mem::swap(&mut opening_cipher, &mut self.common.remote_to_local);
 
+                            let kex_was_active = self.kex.active();
                             match reply(&mut self, &mut handler, &mut pkt).await {
                                 Ok(_) => {},
                                 Err(e) => return Err(e),
                             }
                             buffer.seqn = pkt.seqn; // TODO reply changes seqn internall, find cleaner way
 
+                            if kex_was_active && !self.kex.active() {
+                                buffer.bytes = 0;
+                            } else if self.read_rekey_limit_reached(buffer.bytes) {
+                                debug!("rekey limit reached after {} inbound bytes", buffer.bytes);
+                                self.initiate_rekey()?;
+                            }
+
                             std::mem::swap(&mut opening_cipher, &mut self.common.remote_to_local);
                         }
                     }
                     reading.set(start_reading(stream_read, buffer, opening_cipher));
+                }
+                () = &mut rekey_timer => {
+                    debug!("rekey time limit reached");
+                    self.initiate_rekey()?;
                 }
                 () = &mut keepalive_timer => {
                     self.common.alive_timeouts = self.common.alive_timeouts.saturating_add(1);
@@ -876,19 +891,79 @@ impl Session {
 
     /// Flush the session, i.e. encrypt the pending buffer.
     pub fn flush(&mut self) -> Result<(), Error> {
+        let mut start_rekey = false;
         if let Some(ref mut enc) = self.common.encrypted {
             if enc.flush(
                 &self.common.config.as_ref().limits,
                 &mut self.common.packet_writer,
             )? && self.kex == SessionKexState::Idle
+                && Self::automatic_rekey_eligible(&enc.state)
             {
                 debug!("starting rekeying");
                 if enc.exchange.take().is_some() {
-                    self.begin_rekey()?;
+                    // USERAUTH_SUCCESS was just flushed with the pre-authentication
+                    // compression state. If automatic rekeying is the first
+                    // post-authentication traffic, activate delayed server
+                    // compression before emitting KEXINIT, just as the next peer
+                    // packet would normally do.
+                    if matches!(enc.state, EncryptedState::InitCompression) {
+                        if enc.server_compression.is_deferred() {
+                            enc.server_compression
+                                .init_compress(self.common.packet_writer.compress());
+                        }
+                        enc.state = EncryptedState::Authenticated;
+                    }
+                    start_rekey = true;
                 }
             }
         }
+        if start_rekey {
+            self.begin_rekey()?;
+        }
         Ok(())
+    }
+
+    fn automatic_rekey_eligible(state: &EncryptedState) -> bool {
+        matches!(
+            state,
+            EncryptedState::InitCompression | EncryptedState::Authenticated
+        )
+    }
+
+    fn initiate_rekey(&mut self) -> Result<(), Error> {
+        if let Some(ref mut enc) = self.common.encrypted {
+            enc.rekey_wanted = true;
+            self.flush()?;
+        }
+        Ok(())
+    }
+
+    fn read_rekey_limit_reached(&self, read_bytes: usize) -> bool {
+        !self.kex.active()
+            && self
+                .common
+                .encrypted
+                .as_ref()
+                .is_some_and(|enc| Self::automatic_rekey_eligible(&enc.state))
+            && read_bytes >= self.common.config.limits.rekey_read_limit
+    }
+
+    fn rekey_time_remaining(&self) -> Option<std::time::Duration> {
+        if self.kex.active() {
+            return None;
+        }
+
+        let enc = self.common.encrypted.as_ref()?;
+        if !Self::automatic_rekey_eligible(&enc.state) {
+            return None;
+        }
+
+        let limit = self.common.config.limits.rekey_time_limit;
+        if limit == std::time::Duration::MAX {
+            return None;
+        }
+
+        Some(limit.saturating_sub(Instant::now().duration_since(enc.last_rekey)))
     }
 
     pub fn flush_pending(&mut self, channel: ChannelId) -> Result<usize, Error> {
@@ -1504,8 +1579,11 @@ mod tests {
     use std::num::Wrapping;
     use std::sync::Arc;
 
+    use ssh_encoding::Encode;
+
     use super::*;
-    use crate::compression::{Compression, Decompress};
+    use crate::auth::{AuthRequest, MethodSet};
+    use crate::compression::{Compress, Compression, Decompress};
     use crate::kex::{KEXES, NONE, SessionKexState};
     use crate::session::{CommonSession, Encrypted, EncryptedState, Exchange};
     use crate::sshbuffer::{IncomingSshPacket, PacketWriter, SSHBuffer};
@@ -1515,6 +1593,24 @@ mod tests {
 
     impl crate::server::Handler for TestHandler {
         type Error = crate::Error;
+    }
+
+    struct AcceptNoneHandler;
+
+    impl crate::server::Handler for AcceptNoneHandler {
+        type Error = crate::Error;
+
+        async fn auth_none(&mut self, _user: &str) -> Result<Auth, Self::Error> {
+            Ok(Auth::Accept)
+        }
+    }
+
+    fn none_auth_request(user: &str) -> Vec<u8> {
+        let mut packet = vec![crate::msg::USERAUTH_REQUEST];
+        user.encode(&mut packet).unwrap();
+        "ssh-connection".encode(&mut packet).unwrap();
+        "none".encode(&mut packet).unwrap();
+        packet
     }
 
     fn authenticated_session() -> Session {
@@ -1618,5 +1714,144 @@ mod tests {
         assert!(
             matches!(err, crate::Error::PacketSize(len) if len > crate::cipher::MAXIMUM_DECOMPRESSED_PACKET_LEN)
         );
+    }
+
+
+    #[test]
+    fn automatic_rekey_server_starts_at_inbound_read_limit() {
+        let mut session = authenticated_session();
+        session.common.encrypted.as_mut().unwrap().kex =
+            KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(
+            1 << 30,
+            16,
+            std::time::Duration::from_secs(3600),
+        );
+
+        assert!(!session.read_rekey_limit_reached(15));
+        assert!(session.read_rekey_limit_reached(16));
+        session.initiate_rekey().unwrap();
+
+        assert!(session.kex.active());
+    }
+
+    #[test]
+    fn automatic_rekey_server_waits_until_authentication_completes() {
+        let mut session = authenticated_session();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(
+            0,
+            0,
+            std::time::Duration::from_secs(3600),
+        );
+        let encrypted = session.common.encrypted.as_mut().unwrap();
+        encrypted.state = EncryptedState::WaitingAuthServiceRequest {
+            accepted: false,
+            sent: false,
+        };
+        encrypted.kex = KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        encrypted.server_compression = Compression::ZlibOpenSSH;
+
+        session.flush().unwrap();
+        assert!(
+            !session.kex.active(),
+            "a pre-authentication server write limit must not start rekeying"
+        );
+
+        session.common.encrypted.as_mut().unwrap().state = EncryptedState::InitCompression;
+        session.flush().unwrap();
+        assert!(
+            session.kex.active(),
+            "the same server write limit must start rekeying after auth succeeds"
+        );
+        assert!(
+            matches!(
+                session.common.encrypted.as_ref().unwrap().state,
+                EncryptedState::Authenticated
+            ),
+            "automatic rekey must complete the delayed-compression state transition"
+        );
+        assert!(
+            matches!(session.common.packet_writer.compress(), Compress::Zlib(_)),
+            "KEXINIT after auth success must use delayed server compression"
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_rekey_server_auth_success_arms_idle_deadline_before_next_packet() {
+        let mut session = authenticated_session();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(1 << 30, 1 << 30, std::time::Duration::ZERO);
+        let encrypted = session.common.encrypted.as_mut().unwrap();
+        encrypted.state =
+            EncryptedState::WaitingAuthRequest(AuthRequest::server(MethodSet::server_supported()));
+        encrypted.kex = KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        encrypted.server_compression = Compression::ZlibOpenSSH;
+
+        session
+            .process_packet(&mut AcceptNoneHandler, &none_auth_request("idle-user"))
+            .await
+            .unwrap();
+
+        assert!(matches!(
+            session.common.encrypted.as_ref().unwrap().state,
+            EncryptedState::InitCompression
+        ));
+        assert!(matches!(
+            session.common.packet_writer.compress(),
+            Compress::None
+        ));
+        let remaining = session
+            .rekey_time_remaining()
+            .expect("auth success must arm the finite rekey deadline before another peer packet");
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            tokio::time::sleep(remaining),
+        )
+        .await
+        .expect("the idle post-authentication rekey deadline must wake");
+
+        session.initiate_rekey().unwrap();
+
+        assert!(session.kex.active());
+        assert!(matches!(
+            session.common.encrypted.as_ref().unwrap().state,
+            EncryptedState::Authenticated
+        ));
+        assert!(matches!(
+            session.common.packet_writer.compress(),
+            Compress::Zlib(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn automatic_rekey_server_deadline_wakes_an_idle_authenticated_session() {
+        let mut session = authenticated_session();
+        session.common.encrypted.as_mut().unwrap().kex =
+            KEXES.get(&crate::kex::CURVE25519).unwrap().make();
+        Arc::get_mut(&mut session.common.config)
+            .expect("test session owns its config")
+            .limits = crate::Limits::new(
+            1 << 30,
+            1 << 30,
+            std::time::Duration::ZERO,
+        );
+
+        let remaining = session
+            .rekey_time_remaining()
+            .expect("authenticated sessions with a finite limit need a deadline");
+        tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            tokio::time::sleep(remaining),
+        )
+        .await
+        .expect("an expired rekey deadline must wake without transport activity");
+        session.initiate_rekey().unwrap();
+
+        assert!(session.kex.active());
     }
 }

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -188,6 +188,38 @@ fn test_write_packet_matches_clear_cipher_write_output() {
 }
 
 #[test]
+fn installing_a_cipher_starts_a_new_write_key_epoch() {
+    let mut writer = PacketWriter::clear();
+    writer.packet_raw(b"initial key exchange").unwrap();
+    assert_ne!(writer.buffer().bytes, 0);
+
+    writer.set_cipher(Box::new(cipher::clear::Key {}));
+
+    assert_eq!(writer.buffer().bytes, 0);
+    writer.packet_raw(b"encrypted epoch").unwrap();
+    assert_eq!(writer.buffer().bytes, b"encrypted epoch".len());
+}
+
+#[tokio::test]
+async fn automatic_rekey_read_counter_tracks_payload_bytes() {
+    let payload = b"inbound rekey accounting";
+    let mut writer = PacketWriter::clear();
+    writer.packet_raw(payload).unwrap();
+    let encoded = writer.buffer().buffer.clone();
+    let (mut reader, mut sender) = tokio::io::duplex(encoded.len());
+    sender.write_all(&encoded).await.unwrap();
+    drop(sender);
+
+    let mut buffer = SSHBuffer::new();
+    let mut opening_key = cipher::clear::Key {};
+    cipher::read(&mut reader, &mut buffer, &mut opening_key)
+        .await
+        .unwrap();
+
+    assert_eq!(buffer.bytes, payload.len());
+}
+
+#[test]
 fn test_write_packet_restores_output_buffer_on_error() {
     let mut writer = PacketWriter::clear();
     writer
@@ -290,7 +322,7 @@ fn packet_bytes_compressed_matches_packet_output() {
 pub struct SSHBuffer {
     pub buffer: Vec<u8>,
     pub len: usize,   // next packet length.
-    pub bytes: usize, // total bytes written since the last rekey
+    pub bytes: usize, // total payload bytes read/written since the last rekey
     // Sequence numbers are on 32 bits and wrap.
     // https://tools.ietf.org/html/rfc4253#section-6.4
     pub seqn: Wrapping<u32>,
@@ -557,6 +589,10 @@ impl PacketWriter {
 
     pub fn set_cipher(&mut self, cipher: Box<dyn SealingKey + Send>) {
         self.cipher = cipher;
+        // Every cipher installation starts a new key epoch. In particular,
+        // discard the cleartext KEX packets counted before the initial keys
+        // were installed as well as the previous encrypted epoch on rekey.
+        self.write_buffer.bytes = 0;
     }
 
     pub fn reset_seqn(&mut self) {

--- a/russh/src/sshbuffer.rs
+++ b/russh/src/sshbuffer.rs
@@ -200,6 +200,10 @@ fn installing_a_cipher_starts_a_new_write_key_epoch() {
     assert_eq!(writer.buffer().bytes, b"encrypted epoch".len());
 }
 
+// Unlike the built-in `#[test]`, `#[tokio::test]` is a proc macro that expands
+// even when the crate is not built in test mode, so it needs an explicit
+// `cfg(test)` to keep the `wasm32-wasip1` build (which has no tokio `rt`) green.
+#[cfg(test)]
 #[tokio::test]
 async fn automatic_rekey_read_counter_tracks_payload_bytes() {
     let payload = b"inbound rekey accounting";


### PR DESCRIPTION
## Description

`Limits` exposes `rekey_read_limit` and `rekey_time_limit`, but the only place that consults them is `Encrypted::flush`, which is reached on the write path. A session that mostly downloads, or one that idles, keeps the same keys no matter how the limits are configured. `rekey_write_limit` is also off by the current epoch's cleartext KEX packets, because `SSHBuffer::bytes` is never reset when a cipher is installed.

- `cipher::read` counts inbound payload bytes, and the client and server loops compare that count against `rekey_read_limit`, resetting it when a key exchange completes.
- `PacketWriter::set_cipher` resets the write counter so each key epoch starts at zero.
- Both loops arm a deadline from `rekey_time_limit` and `Encrypted::last_rekey`, so an idle session still rekeys on time.
- Automatic rekeying is gated on completed authentication. Without that, a small `RekeyLimit` makes pre-authentication traffic start a second key exchange while the first is still being set up. On the server, `USERAUTH_SUCCESS` is flushed while the state is still `InitCompression`, so deferred server compression is activated before `KEXINIT` when rekeying is the first post-authentication write.

`Session::initiate_rekey` and `Msg::Rekey` are unchanged and still rekey on demand.

Ten tests cover the read limit, the deadline, the pre- and post-authentication gate on both sides, and the epoch reset. Dropping the byte accounting makes the two `sshbuffer` tests fail.

`compression::tests::partial_flush_packets_round_trip` fails on `main` at d3ae702 as well, and #757 looks like the fix. Everything else passes.

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
