### PR TITLE
Add support hostkeys-prove-00@openssh.com

### DIFF
--- a/russh/src/client/encrypted.rs
+++ b/russh/src/client/encrypted.rs
@@ -962,6 +962,26 @@ impl Session {
                         map_err!(ensure_end(&r))?;
                         let _ = return_channel.send(true);
                     }
+                    Some(GlobalRequestResponse::HostKeysProve {
+                        return_channel,
+                        session_id,
+                    }) => {
+                        let mut signatures = Vec::new();
+                        while !r.is_empty() {
+                            match Bytes::decode(&mut r) {
+                                Ok(signature) => signatures.push(signature.to_vec()),
+                                Err(error) => {
+                                    error!("Error parsing hostkeys proof: {error:?}");
+                                    let _ = return_channel.send(None);
+                                    return Ok(());
+                                }
+                            }
+                        }
+                        let _ = return_channel.send(Some(super::HostKeysProof {
+                            session_id,
+                            signatures,
+                        }));
+                    }
                     None => {
                         error!("Received global request failure for unknown request!")
                     }
@@ -992,6 +1012,9 @@ impl Session {
                     }
                     Some(GlobalRequestResponse::CancelStreamLocalForward(return_channel)) => {
                         let _ = return_channel.send(false);
+                    }
+                    Some(GlobalRequestResponse::HostKeysProve { return_channel, .. }) => {
+                        let _ = return_channel.send(None);
                     }
                     None => {
                         error!("Received global request failure for unknown request!")

--- a/russh/src/client/mod.rs
+++ b/russh/src/client/mod.rs
@@ -81,6 +81,15 @@ mod session;
 #[cfg(test)]
 mod test;
 
+/// Successful raw response to `hostkeys-prove-00@openssh.com`.
+///
+/// Signature verification remains the caller's responsibility.
+#[derive(Debug)]
+pub struct HostKeysProof {
+    pub session_id: Vec<u8>,
+    pub signatures: Vec<Vec<u8>>,
+}
+
 /// Actual client session's state.
 ///
 /// It is in charge of multiplexing and keeping track of various channels
@@ -1969,6 +1978,41 @@ mod tests {
             reply_sender,
         );
         (session, sender, reply_receiver)
+    }
+
+    #[test]
+    fn hostkeys_prove_request_encodes_every_key_blob() {
+        let (mut session, sender, _replies) = keyboard_interactive_session();
+        let host_key = PrivateKey::random(&mut rand::rng(), Algorithm::Ed25519).unwrap();
+        let host_key = host_key.public_key().clone();
+        let (return_channel, _proof) = oneshot::channel();
+
+        session
+            .request_hostkeys_prove(return_channel, std::slice::from_ref(&host_key))
+            .unwrap();
+        drop(sender);
+
+        let written = session.common.encrypted.as_ref().unwrap().write.to_vec();
+        let packet_len =
+            u32::from_be_bytes(written[..4].try_into().unwrap()) as usize;
+        let mut payload = &written[4..4 + packet_len];
+
+        assert_eq!(u8::decode(&mut payload).unwrap(), crate::msg::GLOBAL_REQUEST);
+        assert_eq!(
+            String::decode(&mut payload).unwrap(),
+            "hostkeys-prove-00@openssh.com"
+        );
+        assert_eq!(u8::decode(&mut payload).unwrap(), 1, "want_reply must be set");
+        assert_eq!(
+            Vec::<u8>::decode(&mut payload).unwrap(),
+            host_key.to_bytes().unwrap()
+        );
+        assert!(payload.is_empty());
+
+        assert!(matches!(
+            session.open_global_requests.front(),
+            Some(GlobalRequestResponse::HostKeysProve { .. })
+        ));
     }
 
     #[cfg(feature = "flate2")]

--- a/russh/src/client/session.rs
+++ b/russh/src/client/session.rs
@@ -442,6 +442,36 @@ impl Session {
         Ok(())
     }
 
+    /// Request proof that the server owns each announced OpenSSH host key.
+    pub fn request_hostkeys_prove(
+        &mut self,
+        return_channel: oneshot::Sender<Option<super::HostKeysProof>>,
+        keys: &[crate::keys::PublicKey],
+    ) -> Result<(), crate::Error> {
+        let key_blobs = keys
+            .iter()
+            .map(crate::keys::PublicKey::to_bytes)
+            .collect::<Result<Vec<_>, _>>()?;
+        let Some(ref mut enc) = self.common.encrypted else {
+            let _ = return_channel.send(None);
+            return Ok(());
+        };
+        self.open_global_requests
+            .push_back(crate::session::GlobalRequestResponse::HostKeysProve {
+                return_channel,
+                session_id: enc.session_id.to_vec(),
+            });
+        push_packet!(enc.write, {
+            msg::GLOBAL_REQUEST.encode(&mut enc.write)?;
+            "hostkeys-prove-00@openssh.com".encode(&mut enc.write)?;
+            1u8.encode(&mut enc.write)?;
+            for key_blob in &key_blobs {
+                key_blob.as_slice().encode(&mut enc.write)?;
+            }
+        });
+        Ok(())
+    }
+
     pub fn data(&mut self, channel: ChannelId, data: impl Into<bytes::Bytes>) -> Result<(), crate::Error> {
         let is_rekeying = self.kex.active();
         let common = &mut self.common;

--- a/russh/src/session.rs
+++ b/russh/src/session.rs
@@ -811,6 +811,11 @@ pub(crate) enum GlobalRequestResponse {
     /// request was for StreamLocalForward, sends true for success or false for failure
     StreamLocalForward(oneshot::Sender<bool>),
     CancelStreamLocalForward(oneshot::Sender<bool>),
+    /// OpenSSH host-key ownership proof, including the original session ID.
+    HostKeysProve {
+        return_channel: oneshot::Sender<Option<crate::client::HostKeysProof>>,
+        session_id: Vec<u8>,
+    },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

OpenSSH servers advertise their full host key set with `hostkeys-00@openssh.com` and expect the client to challenge it with `hostkeys-prove-00@openssh.com` before adopting any of the keys. Without that exchange a client cannot implement `UpdateHostKeys` safely, because an announced key is only trustworthy once the server proves it holds the matching private key. russh has no way to send the request today.

`Session::request_hostkeys_prove` sends the global request with `want_reply` set and one blob per candidate key. `REQUEST_SUCCESS` decodes every signature in order into a `HostKeysProof` that also carries the session ID. `REQUEST_FAILURE`, a malformed body, and an unencrypted session all resolve to `None`.

The proof is returned raw. Verifying each signature over `"hostkeys-prove-00@openssh.com" || session_id || key_blob` stays with the caller, which is where the policy for adopting a new key lives anyway.

#759 proposes a generic custom-global-request API. If that lands, this could be rewritten on top of it, though the response decoding would still need somewhere to live.

`compression::tests::partial_flush_packets_round_trip` fails on `main` at d3ae702 as well, and #757 looks like the fix. Everything else passes.

...

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [ ] AI-designed, AI-coded, manually checked
* [x] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
