### PR TITLE
Fix Clippy and minimal-versions CI failures on Rust 1.91

### DIFF
--- a/russh/Cargo.toml
+++ b/russh/Cargo.toml
@@ -17,7 +17,7 @@ default = ["flate2", "aws-lc-rs", "rsa"]
 # Crypto backends: enable at least one of `aws-lc-rs` or `ring`.
 aws-lc-rs = ["dep:aws-lc-rs"] # Default crypto backend.
 async-trait = ["dep:async-trait"]
-legacy-ed25519-pkcs8-parser = ["yasna"]
+legacy-ed25519-pkcs8-parser = ["yasna", "num-bigint-04"]
 # Danger: 3DES cipher is insecure.
 des = ["dep:des"]
 # Danger: DSA algorithm is insecure.
@@ -63,6 +63,10 @@ md5 = "0.8"
 ml-kem = "0.3"
 module-lattice = "0.2"
 num-bigint = { version = "0.5", features = ["rand_0_10"] }
+# `yasna` accepts any num-bigint 0.4; only listed to raise the floor, because
+# a cargo-minimal-versions failure below 0.4.6 resolves `div_ceil` to the
+# inherent `u64::div_ceil` instead of `Integer::div_ceil`.
+num-bigint-04 = { package = "num-bigint", version = "0.4.6", optional = true }
 p256 = { version = "0.14", features = ["ecdh"] }
 p384 = { version = "0.14", features = ["ecdh"] }
 p521 = { version = "0.14", features = ["ecdh"] }

--- a/russh/src/lib.rs
+++ b/russh/src/lib.rs
@@ -4,7 +4,13 @@
     clippy::indexing_slicing,
     clippy::panic
 )]
-#![allow(clippy::single_match, clippy::upper_case_acronyms)]
+// Rust 1.91 extended `collapsible_if` to suggest let-chains, which rustfmt
+// does not yet format; revisit once it does.
+#![allow(
+    clippy::collapsible_if,
+    clippy::single_match,
+    clippy::upper_case_acronyms
+)]
 #![allow(macro_expanded_macro_exports_accessed_by_absolute_paths)]
 // length checked
 // Copyright 2016 Pierre-Étienne Meunier


### PR DESCRIPTION
## Description

`Clippy` and `Minimal-versions` have been failing on `main` since the 1.91 toolchain reached the runners, independently of any pull request: https://github.com/Eugeny/russh/actions/runs/33791529793 at 8a51a0d.

Clippy 1.91 extended `collapsible_if` to nested `if let`, which flags 40 sites. `cargo clippy --fix` rewrites them as let-chains, but neither stable rustfmt nor nightly 1.10.0 reformats the result, so every body keeps its pre-collapse indentation until it is fixed by hand. That churn lands in the session and encrypted modules that most open PRs touch, so this allows the lint next to the two allows already in `lib.rs` rather than reformatting them now.

Under minimal versions, `yasna`'s `num-bigint = "0.4"` resolves to 0.4.0, whose `bits().div_ceil(&u64::from(bits))` now picks the inherent `u64::div_ceil` over `Integer::div_ceil` and fails to compile. 0.4.6 switched those three call sites to UFCS, so the floor is raised with a renamed optional dependency tied to the same feature as `yasna`, the same way `cipher`, `ghash`, `polyval` and `universal-hash` are already pinned in this file.

Verified with the CI commands: `cargo clippy` with and without `--all-features`, `cargo minimal-versions check --all-features --no-dev-deps`, `cargo fmt --check`, `cargo test --all-features`, plus the 1.89.0 `wasm32-wasip1` build and an MSRV check.

## AI Usage

Choose the level of AI involvement for this PR.

* [ ] Fully vibe coded
* [x] AI-designed, AI-coded, manually checked
* [ ] Human-designed, AI-coded
* [ ] Human-designed, human-coded (includes AI autocompletions and boilerplate gen)

*<sub>This is not to block AI contributions but rather to speed up PR review (saves time on trying to deduce the logic behind AI hallucinations).</sub>*
